### PR TITLE
Issue #281: Remove 1 from the list of primes printed by DEMOAST1

### DIFF
--- a/assist/demo/DEMOAST1.MLC
+++ b/assist/demo/DEMOAST1.MLC
@@ -10,8 +10,7 @@
 *********************************************************************
 DEMOAST1 CSECT
          USING *,R15
-         XPRNT =C'           1',12 DISPLAY 1, 2, 3 AS PRIMES
-         XPRNT =C'           2',12
+         XPRNT =C'           2',12 DISPLAY FIRST TWO PRIMES
          XPRNT =C'           3',12
          LA    R3,3          R3 = NUMBER TO TEST FOR PRIME
          LA    R5,PRIMES     R5 -> LAST PRIME IN TABLE OF PRIMES


### PR DESCRIPTION
After initially updating DEMOAST1.MLC to correctly print the primes less than 100, it was noticed that the program included 1 in the list of primes. The program has been modified to not include 1 in the list of primes.
This fixes #281