### PR TITLE
fix issue 244 by updating bat\RUNVSEDEMOS.BAT

### DIFF
--- a/bat/RUNVSEDEMOS.BAT
+++ b/bat/RUNVSEDEMOS.BAT
@@ -1,10 +1,11 @@
 rem run vse demos under z390
+rem 2021/06/09 dsh fix issue #244 by adding "call "
 cd..
-bat\asmlg vse\demo\DEMOVSE1 sysmac(vse\mac+mac)
+call bat\asmlg vse\demo\DEMOVSE1 sysmac(vse\mac+mac)
 pause verify DEMOVSE1 ended ok
-bat\asmlg vse\demo\DEMOVSE2 sysmac(vse\mac+mac)
+call bat\asmlg vse\demo\DEMOVSE2 sysmac(vse\mac+mac)
 pause verify DEMOVSE2 ended ok
 set SYSUT1=vse\demo\DEMOVSE3.TF1
 set SYSUT2=vse\demo\DEMOVSE3.TF2
-bat\asmlg vse\demo\DEMOVSE3 sysmac(vse\mac+mac)
+call bat\asmlg vse\demo\DEMOVSE3 sysmac(vse\mac+mac)
 pause verify DEMOVSE3 copied DEMOVSE3.TF1 to DEMOVSE3.TF2


### PR DESCRIPTION
Fix issue 244 by updating bat\RUNVSEDEMOS.BAT to include call before each bat\ASMLG command.  The previous bat fiel was terminating after first demo without pause to verify and without continuing on to demos 2 and 3.  All work correctly now.  The original issue was raised on v1707 where vse assembly was resulting in base register error.  John fixed that error and successfully tested the vse demos using bash scripts on Linux.