### PR TITLE
Move to Java 11 for automated build and package

### DIFF
--- a/.github/actions/build/Dockerfile
+++ b/.github/actions/build/Dockerfile
@@ -1,5 +1,5 @@
 # Container image that runs your code
-FROM adoptopenjdk/openjdk8
+FROM eclipse-temurin:11
 
 # install git so we can get version label
 RUN apt -y update;apt -y install git zip

--- a/.github/workflows/buildwin.yml
+++ b/.github/workflows/buildwin.yml
@@ -9,6 +9,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '11'
       - name: Build z390 (win)
         shell: cmd
         run: call .\BUILD.BAT


### PR DESCRIPTION
This pull request is updating the automated builds to move from Java 8 to Java 11.

* Java 11 is the next long term support Java version after Java 8 -> extended support until 2026.
* Java 17 is the current LTS Java version providing extended support until 2029 - released Sept 2021.

This also includes a move to from AdoptOpenJDK to Eclipse Temurin Java. Same Java, just new project home/governance.
See https://blog.adoptopenjdk.net/2021/03/transition-to-eclipse-an-update/ for details
