### PR TITLE
issue #343 increase maxline to 400000 and fix error messages

### DIFF
--- a/src/az390.java
+++ b/src/az390.java
@@ -412,7 +412,8 @@ public  class  az390 implements Runnable {
 		* 2021-02-07 RPI 2226 correct RSYb EB17 STCCTM R1,M3,D2(B2) and fix VNOT not setting v3=v2
         * 2821-04-26 Issue #239 fix no error on undefined sym for RIL i2 operand
         * 2021-08-20 DSH issue #230 correct vector instruction erros reported by Dan Greiner
-        * 2021-09-07 dsh #230 fix E7CC option, fix E7C0-E7C7 OR 8 with operand m4 or m6		
+        * 2021-09-07 dsh #230 fix E7CC option, fix E7C0-E7C7 OR 8 with operand m4 or m6	
+        ^ 2022-01-16 dsh #343 move abort for exceeding maxline 		
     *****************************************************
     * Global variables                        last rpi
     *****************************************************/
@@ -5445,8 +5446,7 @@ private void load_bal(){
      	    }
 	    }
 		get_bal_line();
-		while (!bal_eof && bal_line != null
-				&& tot_bal_line < tz390.opt_maxline){
+		while (!bal_eof && bal_line != null){
             save_bal_line();
 			parse_bal_line();
             bal_op_index = find_bal_op();
@@ -5455,15 +5455,15 @@ private void load_bal(){
 	        }
  			if  (bal_line != null){
 				tot_bal_line++;
+				if (tot_bal_line >= tz390.opt_maxline){ // issue #343 moved here to catch before end
+			        abort_error(83,"maximum source lines exceeded");
+		        }
 	            get_bal_line();
 			}
 		}
 		if (!end_found){
 			process_end();
-		}
-		if (tot_bal_line >= tz390.opt_maxline){
-			abort_error(83,"maximum source lines exceeded");
-		}
+		}		
         if (tz390.opt_tracea){
         	tz390.put_trace("PASS " + cur_pass + " TOTAL ERRORS = " + az390_errors);
         }

--- a/src/mz390.java
+++ b/src/mz390.java
@@ -433,6 +433,7 @@ public  class  mz390 {
 	 * 2020-12-28 dsh rpi 2226 change sysvsam default to 1 see tz390 zvsam option
 	 * 2021-01-07 dsh rpi 2228 supress error searching for symbol with option NOASM for ZPARTRS
 	 * 2021-08-11 dsh issue #318 dup of 261 fix identified by John Ganci, let az390 convert sdts to numeric as macro may test for sdt strings
+	 * 2022-01-17 dsh issue #343 abort if maxline exceeded
 	 ********************************************************
 	 * Global variables                       (last RPI)
 	 *****************************************************/
@@ -559,6 +560,7 @@ public  class  mz390 {
 	int[]        mac_ictl_cont  = null; // RPI 728
 	int cur_mac_line_num = 0;
 	int cur_mac_file_num = 0;
+	int tot_get_mac = 0; // #343 count bal lines generated and chk opt_maxline
 	boolean mac_mend_eof = false;  // RPI 740
 	String mac_line = null;
 	String mac_label = null;
@@ -2484,6 +2486,10 @@ public  class  mz390 {
 			while (retry){
 				retry = false;  
 				tz390.systerm_io++;
+				tot_get_mac++; // issue #343 count bal lines 
+				if (tot_get_mac > tz390.opt_maxline){
+				   abort_error(270,"maxium bal lines exceeded");
+				}
 				temp_line = mac_file_buff[cur_mac_file].readLine();
 				if (temp_line != null && tz390.opt_chksrc >= 3){
 					temp_line = tz390.trim_trailing_spaces(temp_line,0); // RPI 1143 
@@ -3486,7 +3492,7 @@ public  class  mz390 {
 		 * pass text_line to az390 and update
 		 * the az390 copy of mz390_errors
 		 */
-		if (az390 != null){
+		if (az390 != null){ 
 			if (az390.lookahead_mode){
 				if (text_line == null || text_line.length() == 0 || text_line.charAt(0) != '*'){
 					abort_error(193,"invalid pass request during lookahead");
@@ -12578,7 +12584,7 @@ public  class  mz390 {
     	 */
     	last_ainsert--;
     	if (tot_mac_line >= last_ainsert){
-    		abort_error(270,"maximum source lines MAXLINE exceeded");
+    		abort_error(270,"maximum ainsert source lines MAXLINE exceeded");
     		return;
     	}
     	mac_file_prev_line[last_ainsert] = mac_file_prev_line[mac_line_index];

--- a/src/tz390.java
+++ b/src/tz390.java
@@ -310,6 +310,7 @@ public  class  tz390 {
     * 2021-04-19 JJG Replace Linux/Mac Perl usage with Linux shell; add variable procdir which
     *                contains "bat" for Windows, "bash" for Linux/Mac.
     * 2021-09-07 dsh #230 fix E7CC option, fix E7C0-E7C7 OR 8 with operand
+	* 2022-01-16 dsh #343 increase maxline from 200000 to 400000 for rpi\zivp.asm from Dan Greiner
 	********************************************************
     * Shared z390 tables                  (last RPI)
     *****************************************************/
@@ -432,7 +433,7 @@ public  class  tz390 {
     int opt_maxfile = 1000;     // RPI 707 max concourrent files open
     int opt_maxgbl  = 100000;   // RPI 284
     int opt_maxlcl  = 100000;   
-    int opt_maxline = 200000;
+    int opt_maxline = 400000;  // issue #343 increased from 200000 to 400000
     int opt_maxlog  = 1000000; // RPI 731
     int opt_maxparm = 10000;
     int opt_maxpass = 2;       // RPI 920 maximum az390 passes for nested symbol refs


### PR DESCRIPTION
This fix increases maxline from 200000 to 400000 and fixes error messages in mz390 and az390 if limit exceeded.
This fix is targeted for z390 v1.8.1.  I've added PTF link to www.z390.info for those who want fix now.

workaround is to specify maxline(400000) to override 200000.  But if max bal lines exceeds 400000, incorrect results without error message can occur.