### PR TITLE
Release notes for v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,20 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v1.8.0]
 
-## [1.7.8] - 2021-11-26
 ### Added
-- First release hosted and built on Github.
-- Initial support for zVSAM version 2
+- First official release hosted and built on GitHub.
+- Updates to copyright and license
 - Support for additional z/Architecture instructions
-- Added missing zpar and demo files
-- Bash native scripts for use on unix based OS's
-- Initial markdown documentation
-- Automated build process (Windows/Linux)
+- Bash native scripts for use on unix based OS's (MacOS, Linux)
+- Initial markdown documentation - see https://z390development.github.io/z390
+- Automated build and packaging process (Windows/Linux)
+- Add Large Block Interface (LBI) support for BSAM read/write access method
+- Initial support for zVSAM version 2
+- zCICS implementation now works under MacOS/Linux
 
 ### Changed
-- z390 commands can now be run from any directory
+- z390 command scripts run from any directory
 - z390 command scripts no longer pause to allow automation
 - Project structure standards and reorganization
 
@@ -25,7 +26,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Perl scripts to support z390 on Unix based OS - use native Bash script
 
 ### Removed
+- The z390 distribution no longer contains Java source. If you
+want to rebuild z390, then you should clone the GitHub repository
+and issue the build script.
 ### Fixed
-- #230 - correct vector instruction errors reported by Dan Greiner
-- #321 - Fix/update RT tests for qsam and bsam support for Large Block Interface
-- #245 - Fix CICS build jobs
+
+* #343 Increase maxlines to 400000
+* #335 Correct ACALL to support parms using created vars () (dsh33782)
+* #291, #305 Fix ASSIST instruction compatibility (John Ganci)
+* #321 QSAM get recfm=vt not setting LLLL correctly for LBI large block
+* #318 Do not replace self defining terms with numeric values
+* #337 remove perl ref in sz390.java and add CMDPROC test programs (John Ganci)
+* #245 update cics directories and bat files plus new bat\readme.txt (dsh33782)
+* #321 fix and update rt tests for qsam and bsam support for LBI large block interface (dsh33782)
+* #230 correct vector instruction errors reported by Dan Greiner (dsh33782)
+* Various fixes to get zCICS working with current release


### PR DESCRIPTION
The text in CHANGELOG.md will be used as the release notes for the release.
I have attempted to summarise the updates since v1.7.8.
All suggestions welcome.
