### PR TITLE
fix LTORG issue 327 to align odd literals to even boundary

### DIFF
--- a/rt/bat/RUNASMTESTS.BAT
+++ b/rt/bat/RUNASMTESTS.BAT
@@ -1,6 +1,6 @@
 @if /I "%1" == "tron" (echo on) else (echo off)
 rem regression test z390 instructions
-
+rem 2022-03-28 DSH TESTLITS added for issue #327
 setlocal
 if /I "%1" == "tron" (set z_TraceMode=tron
                       shift /1
@@ -19,6 +19,7 @@ call bat\asmlg %z_TraceMode% tests\testins4 trace sysmac(mac) noloadhigh        
 call bat\asmlg %z_TraceMode% tests\testins5 trace sysmac(mac) noloadhigh optable(z390) || goto error
 call bat\asmlg %z_TraceMode% tests\testdfp1 trace sysmac(mac) noloadhigh optable(z390) || goto error
 call bat\asmlg %z_TraceMode% tests\testdfp2 trace sysmac(mac) noloadhigh optable(z390) || goto error
+call bat\asmlg %z_TraceMode% tests\testlits trace sysmac(mac) noloadhigh optable(z390) || goto error
 call rt\bat\ZOPCHECK %z_TraceMode%                                                     || goto error
 set z_ReturnCode=0
 goto return

--- a/src/az390.java
+++ b/src/az390.java
@@ -413,7 +413,8 @@ public  class  az390 implements Runnable {
         * 2821-04-26 Issue #239 fix no error on undefined sym for RIL i2 operand
         * 2021-08-20 DSH issue #230 correct vector instruction erros reported by Dan Greiner
         * 2021-09-07 dsh #230 fix E7CC option, fix E7C0-E7C7 OR 8 with operand m4 or m6	
-        ^ 2022-01-16 dsh #343 move abort for exceeding maxline 		
+        * 2022-01-16 DSH #343 move abort for exceeding maxline 
+        * 2022-03-28 DSH #327 fix az390 to force odd literals to even address for access by relative halfword offset counts	
     *****************************************************
     * Global variables                        last rpi
     *****************************************************/
@@ -10589,6 +10590,8 @@ private void gen_ltorg(){
 private void gen_lit_size(int size){
 	/*
 	 * generate literal dc's of specified size
+           * force all length 1 lits to even addr for access by relative halfword offsets in LARL etc.  per issue #327
+           * see regression test rt\test\TESTLITS.MLC which fails on previous releases
 	 */
 	cur_lit = 0;
 	while (cur_lit < tot_lit){
@@ -10598,6 +10601,9 @@ private void gen_lit_size(int size){
 				){			
 			lit_gen[cur_lit] = 1;
 			lit_esd[cur_lit] = esd_base[cur_esd]; // RPI 457
+                             if   (size == 1 && loc_ctr != (loc_ctr/2*2)){
+                                  loc_ctr = loc_ctr + 1;  // issue #327 force lits on even addr for ref by halfword offset counts
+                             }
 			process_dc(3);
 			if (gen_obj_code && tz390.opt_list){ // RPI 484
 				if (list_obj_code.length() < 16){

--- a/tests/TESTLITS.MLC
+++ b/tests/TESTLITS.MLC
@@ -1,0 +1,24 @@
+*********************************************************************
+* Copyright 2021 Don Higgins               *
+* This source code is part of z390 assembler/emulator package       *
+* The z390 package is distributed under GNU general public license  *
+* Author - Don Higgins                                              *
+* Date   - 2021/11/10    
+*********************************************************************
+* 2022-03-28 DSH RENAME AND VERIFY LITERAL ADDR AND VALUE                                            *
+*********************************************************************
+         TITLE 'TESTLITS TEST LARL REF TO OLD LENGTH LIT'
+TESTLITS SUBENTRY
+          LARL   R0,=C'A'        FIRST ODD LIT ON EVEN BOUNDARY
+          LARL   R1,=C'ABC'   SECOND ODD LIT WAS ON ODD BOUND
+           CLC 0(3,R1),=C'ABC'
+           BNE     BADLIT           VERIFY VALUE OF LITERAL
+           N           R1,=F'1'
+           BNZ     BADADDR      VERIFY EVEN ADDRESS FOR USE BY LARL    
+           SUBEXIT RC=0
+BADADDR WTO    'ERROR - LITERAL AT ODD ADDRESS'
+          SUBEXIT RC=16
+BADLIT      WTO    'ERROR - LITERAL DOES NOT MATCH'
+           SUBEXIT RC=16
+           EQUREGS                              
+           END


### PR DESCRIPTION
Issue #327 assember error due to LARL referencing odd address literal has been fixed by changing az390.java to force even addresss for all literals.  A new regression test tests\TESTLITS.MLC has been added to rt\bat\RUNASMTESTS.BAT.  The BUILD.BAT regression test has run successfully locally.