### PR TITLE
Fix build error "Not a git repo."

### DIFF
--- a/.github/actions/build/entrypoint.sh
+++ b/.github/actions/build/entrypoint.sh
@@ -1,3 +1,4 @@
 #!/bin/sh -l
+git config --global --add safe.directory ${GITHUB_WORKSPACE}
 echo "Running ${GITHUB_WORKSPACE}/build.sh"
 ${GITHUB_WORKSPACE}/build.sh

--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,8 @@ docenv/
 z390.properties
 
 # z390 dist and build
-dist/
-build/
+/dist/
+/build/
 
 # generated spm files in mac/spm except readme
 mac/spm/*

--- a/bat/RELVER.BAT
+++ b/bat/RELVER.BAT
@@ -33,7 +33,7 @@ if %z_Version% EQU "Uncontrolled" (if /I "%1" NEQ "FORCE" (echo Version is uncon
                                    )                       )
 rem relver: use git to set z390.properties version details
 echo z390 version "%z_Version%"
-echo version=%z_Version% > z390.properties
+echo version=%z_Version%> z390.properties
 set z_ReturnCode=%ERRORLEVEL%
 
 :return


### PR DESCRIPTION
The `Not a git repo` message has been causing the linux build job to fail.
After investigation, I tracked the cause to a Git security issue and subsequent patch that has been applied.

* https://github.blog/2022-04-12-git-security-vulnerability-announced/
* https://github.com/actions/checkout/issues/760

Once this is merged, it should address the build issues.