### PR TITLE
Fix quickstart doco - wrong file extension for COBOL

### DIFF
--- a/doc/getting_started/quickstart.md
+++ b/doc/getting_started/quickstart.md
@@ -59,7 +59,7 @@ The following is a simple *Hello world* application written in COBOL.
             STOP RUN.
 ```
 
-Add the contents of this to a file named 'HELLO.MLC'.
+Add the contents of this to a file named 'HELLO.CBL'.
 
 Now run the following z390 command to assemble, link and run the COBOL program.
 


### PR DESCRIPTION
Fixes issue related to wrong file extension using in the quickstart docs. Raised in #461
https://z390development.github.io/z390/getting_started/quickstart/#hello-zcobol


