### PR TITLE
fetch upstream when git describe error during build

### DIFF
--- a/bash/relver
+++ b/bash/relver
@@ -9,6 +9,13 @@ cd ..
 
 VER="Uncontrolled";
 
+get_tags() {
+    if ! git config remote.upstream.url > /dev/null; then
+        git remote add upstream https://github.com/z390development/z390.git
+    fi
+    git fetch -p upstream
+}
+
 # is git installed
 $(git --version > /dev/null 2>&1)
 GIT_INSTALLED=$?
@@ -21,6 +28,12 @@ else
     if [ ${GIT_REPO} != 0 ]; then
         echo >&2 "Not a git repo.";
     else
+        $(git describe > /dev/null 2>&1)
+        GIT_DESCRIBE=$?
+        if [ ${GIT_DESCRIBE} != 0 ]; then
+            echo >&2 "Unable to git describe - fetching tags from upstream"
+            get_tags
+        fi
         VER=$(git describe);
     fi    
 fi

--- a/bat/RELVER.BAT
+++ b/bat/RELVER.BAT
@@ -13,16 +13,49 @@ rem ----- Lvl(%z_NestLevel%) Start %0 %1 %2 %3 %4 %5 %6 %7 %8 %9
 pushd %~dps0..
 set z_Version="Uncontrolled"
 
-git --man-path >NUL
-
+rem -- is git installed?
+git --version >NUL
 set z_Git_Installed=%ERRORLEVEL%
 if %z_Git_Installed% NEQ 0 (echo Git is not installed
                             goto final
-                            ) 
+                            )
 
+rem -- are we in a git repository?
+git rev-parse --is-inside-work-tree >NUL
+set z_Git_WorkTree=%ERRORLEVEL%
+if %z_Git_WorkTree% NEQ 0 (echo Git cannot determine whether we're in a work tree
+                           goto final
+                           )
 for /F "tokens=* USEBACKQ" %%F in (`git rev-parse --is-inside-work-tree`) do (set z_Git_Repo=%%F)
 if "%z_Git_Repo%" NEQ "true" (echo Not a git repository
                               goto final)
+
+rem -- get git to describe the repo
+git describe >NUL
+set z_Git_Describe=%ERRORLEVEL%
+if %z_Git_Describe% EQU 0 goto describe
+echo Unable to git describe - fetching tags from upstream
+
+rem -- make sure we have an upstream defined
+git config remote.upstream.url >NUL
+set z_Git_Remote=%ERRORLEVEL%
+if %z_Git_Remote% EQU 0 goto fetch_upstream
+rem -- use default to set the remote location
+git remote add upstream https://github.com/z390development/z390.git
+set z_Git_SetRemote=%ERRORLEVEL%
+if %z_Git_SetRemote% NEQ 0 (echo Git cannot set remote
+                            goto final
+                            )
+
+:fetch_upstream
+rem -- fetch upstream to fix missing git tags
+git fetch -p upstream
+set z_Git_Fetch=%ERRORLEVEL%
+if %z_Git_Fetch% NEQ 0 (echo Git cannot fetch from upstream
+                        goto final
+                        )
+
+:describe
 for /F "tokens=* USEBACKQ" %%I in (`git describe`) do set z_Version=%%I
 
 :final


### PR DESCRIPTION
This request is to assist new contributors to the z390 project.

Fixes #472

The flow for a new contributor is that they would fork the main repository in GitHub and then clone the fork to their local machine.
What we have discovered is that the GitHub fork process does not bring across the tags from the main repo, and this extends to the local copy. This lack of tags causes a build issue. 

When a build is executed, it creates a z390.properties file which contains the current version which is sourced from the git repo tags and is included in the jar. The properties file is generated by the relver script (bash/relvel, bat/RELVER.BAT) 
Because the clone does not have any tags so the git describe action fails and you cannot override by using FORCE parameter.

Solution:
The relver script has been modified to fetch upstream tags when a git describe error is encountered.
If not present, the script will add the upstream remote required to fetch the tags. 
I have tested this against a new fork which does not have the tags present (chookperson/z390)

@abekornelis - are you able to update bat/RELVER.BAT to do the equivalent function for Windows. I don't have any Windows machines I can build this with. Also let me know if you are OK with the approach taken.