### PR TITLE
IS458: B2C and X2C changes for issue 458

### DIFF
--- a/rt/bash/runasmtests
+++ b/rt/bash/runasmtests
@@ -25,6 +25,7 @@ bash/asmlg rt/mlc/TESTDC1  trace noloadhigh $sysmac $optable
 bash/asmlg rt/mlc/TESTASC1 ASCII trace noloadhigh $sysmac $optable
 bash/asmlg rt/mlc/TESTDC2  trace noloadhigh $sysmac $optable
 bash/asmlg rt/mlc/TESTDC3  trace noloadhigh $sysmac $optable
+bash/asmlg rt/mlc/TB2CX2C  trace noloadhigh $sysmac $optable
 rt/bash/zopcheck
 
 # if we get here, there were no errors

--- a/rt/bat/RUNASMTESTS.BAT
+++ b/rt/bat/RUNASMTESTS.BAT
@@ -28,6 +28,7 @@ call bat\asmlg %z_TraceMode% rt\mlc\TESTDC1  trace sysmac(mac) noloadhigh optabl
 call bat\asmlg %z_TraceMode% rt\mlc\TESTASC1 trace sysmac(mac) noloadhigh optable(z390) ASCII || goto error
 call bat\asmlg %z_TraceMode% rt\mlc\TESTDC2  trace sysmac(mac) noloadhigh optable(z390)       || goto error
 call bat\asmlg %z_TraceMode% rt\mlc\TESTDC3  trace sysmac(mac) noloadhigh optable(z390)       || goto error
+call bat\asmlg %z_TraceMode% rt\mlc\TB2CX2C  trace sysmac(mac) noloadhigh optable(z390)       || goto error
 call rt\bat\ZOPCHECK %z_TraceMode%                                                            || goto error
 
 rem -- all checks passed without issue

--- a/rt/mlc/TB2CX2C.MLC
+++ b/rt/mlc/TB2CX2C.MLC
@@ -10,27 +10,32 @@ LP1      DS    0H
          LM    6,9,0(3)            R6 --> gen val, R7 --> gen val len,
 *                                  R8 --> exp val, R9 = exp val len
          C     9,0(,7)             Exp val len = gen val len?
-         BNE   Error1              No; error
+         BNE   ErrorLen            No; error
          LTR   9,9                 Length 0?
          BZ    NX1                 Yes; next test
          BCTR  9,0                 Length code
          EX    9,Compare           Gen val = exp val?
-         BNE   Error2              No; error
+         BNE   ErrorVal            No; error
 NX1      DS    0H
          BXLE  3,4,LP1             Next test
          WTO   'All tests successful'
          SR    15,15               All tests okay
          B     Exit                Exit with return code
-Error1   DS    0H
-         SNAP  ID=1,PDATA=(GPR),                                       X
-               TEXT='Length error; R2 = failing test number'
+ErrorLen DS    0H
+         LA    1,W1LenLit          Literal for WTO
+         B     Error               Show error
+ErrorVal DS    0H
+         LA    1,W1ValLit          Literal for WTO
+*NSI     B     Error               Show error
+Error    DS    0H
+         MVC   W1Lit,0(1)          Copy literal to WTO
+         ST    2,FW                Convert test number
+         UNPK  DW(9),FW(5)         ... to printable hex
+         TR    DW,H2P              Finish conversion
+         MVC   W1TstNum,DW         Copy to WTO
+         WTO   MF=(E,WTO1)         Show error message
          LA    15,8                Set error return code
-         B     Exit                Exit with return code
-Error2   DS    0H
-         SNAP  ID=2,PDATA=(GPR),                                       X
-               TEXT='Value error; R2 = failing test number'
-         LA    15,8                Set error return code
-         B     Exit                Exit with return code
+*NSI     B     Exit                Exit with return code
 Exit     DS    0H
          L     14,12(,13)          Restore caller's registers
          LM    0,12,20(13)         ... except R15
@@ -40,13 +45,20 @@ Exit     DS    0H
 *
 Compare  CLC   0(*-*,6),0(8)       Compare gen val to exp val
 *
+W1ValLit DC    C'Value '
+W1LenLit DC    C'Length'
+*
+WTO1     WTO   'Error: xxxxxx  test number xxxxxxxx',MF=L
+W1Lit    EQU   WTO1+4+7,6
+W1TstNum EQU   WTO1+4+27,8
+*
          DS    0D
 TTbl     DC    A(T1,16,TN,0)           Table of tests
 T1       DS    0D
-         DC    A(B1,B1L,B1V,L'B1V)     1
+         DC    A(B1,B1L,0,0)           1
          DC    A(B2,B2L,B2V,L'B2V)     2
          DC    A(B3,B3L,B3V,L'B3V)     3
-         DC    A(X1,X1L,X1V,L'X1V)     4
+         DC    A(X1,X1L,0,0)           4
          DC    A(X2,X2L,X2V,L'X2V)     5
          DC    A(X3,X3L,X3V,L'X3V)     6
          DC    A(X4,X4L,X4V,L'X4V)     7
@@ -54,21 +66,34 @@ T1       DS    0D
 *        Put new tests above this line
 ***********************************************************************
 TN       EQU   *-16                Last test
-B1V      DC    C''
+*
+***********************************************************************
+*        Expected values
+***********************************************************************
+*
+*B1V      DC    C''                error on z/OS HLASM
 B2V      DC    C'3'
 B3V      DC    C'*1'
-X1V      DC    C''
+*X1V      DC    C''                error on z/OS HLASM
 X2V      DC    X'F3'
 X3V      DC    X'F1F2F3F4F5'
 X4V      DC    X'00F1F2'
 *
+***********************************************************************
+*        Generated values and lengths
+***********************************************************************
+*
          GBLC  &C
          GBLA  &A
-***********************************************************************
+*
 ***      B2C('')
 &C       SETC B2C('')
-B1       DC    C'&C'               '' C''
-B1L      DC    AL4(L'B1)
+&A       SETA  K'&C
+*B1       DC    C'&C'               '' C''  error on z/OS HLASM
+*B1L      DC    AL4(L'B1)
+B1       DS    0C
+B1L      DC    AL4(&A)
+*
 ***      B2C('11110011')
 &C       SETC B2C('11110011')
 B2       DC    C'&C'               '11110011' C'3'
@@ -78,11 +103,16 @@ B2L      DC    AL4(L'B2)
 &C       SETC B2C('101110011110001')
 B3       DC    C'&C'               '101110011110001' C'*1'
 B3L      DC    AL4(L'B3)
-***********************************************************************
+*
+*
+*
 ***      X2C('')
 &C       SETC X2C('')
-X1       DC    C'&C'               '' C''
-X1L      DC    AL4(L'X1)
+&A       SETA  K'&C
+*X1       DC    C'&C'               '' C''  error on z/OS HLASM
+*X1L      DC    AL4L'X1)
+X1       DS    0C
+X1L      DC    AL4(&A)
 *
 ***      X2C('F3')
 &C       SETC X2C('F3')
@@ -100,5 +130,10 @@ X4       DC    C'&C'               '0F1F2' C'n12' n=X'00'
 X4L      DC    AL4(L'X4)
 ***********************************************************************
 *
+DW       DS    D,XL1                Doubleword work and pad
+FW       DS    F,XL1                Fullword work and pad
+*
+H2P      EQU   *-240                Hex to printable hex
+         DC    C'0123456789ABCDEF'
+*
          END
-

--- a/rt/mlc/TB2CX2C.MLC
+++ b/rt/mlc/TB2CX2C.MLC
@@ -1,0 +1,104 @@
+         TITLE 'Test B2C and X2C changes for issue #458'
+TB2CX2C  CSECT
+         STM   14,12,12(13)        Save caller's registers
+         LR    12,15               R12 = base register
+         USING TB2CX2C,12          Establish addressability
+         LM    3,5,TTbl            R3 -> 1st, R4 = len 1, R5 -> last
+         SR    2,2                 Test number
+LP1      DS    0H
+         AHI   2,1                 Current test number
+         LM    6,9,0(3)            R6 --> gen val, R7 --> gen val len,
+*                                  R8 --> exp val, R9 = exp val len
+         C     9,0(,7)             Exp val len = gen val len?
+         BNE   Error1              No; error
+         LTR   9,9                 Length 0?
+         BZ    NX1                 Yes; next test
+         BCTR  9,0                 Length code
+         EX    9,Compare           Gen val = exp val?
+         BNE   Error2              No; error
+NX1      DS    0H
+         BXLE  3,4,LP1             Next test
+         WTO   'All tests successful'
+         SR    15,15               All tests okay
+         B     Exit                Exit with return code
+Error1   DS    0H
+         SNAP  ID=1,PDATA=(GPR),                                       X
+               TEXT='Length error; R2 = failing test number'
+         LA    15,8                Set error return code
+         B     Exit                Exit with return code
+Error2   DS    0H
+         SNAP  ID=2,PDATA=(GPR),                                       X
+               TEXT='Value error; R2 = failing test number'
+         LA    15,8                Set error return code
+         B     Exit                Exit with return code
+Exit     DS    0H
+         L     14,12(,13)          Restore caller's registers
+         LM    0,12,20(13)         ... except R15
+         BR    14                  Return to caller
+*
+         LTORG
+*
+Compare  CLC   0(*-*,6),0(8)       Compare gen val to exp val
+*
+         DS    0D
+TTbl     DC    A(T1,16,TN,0)           Table of tests
+T1       DS    0D
+         DC    A(B1,B1L,B1V,L'B1V)     1
+         DC    A(B2,B2L,B2V,L'B2V)     2
+         DC    A(B3,B3L,B3V,L'B3V)     3
+         DC    A(X1,X1L,X1V,L'X1V)     4
+         DC    A(X2,X2L,X2V,L'X2V)     5
+         DC    A(X3,X3L,X3V,L'X3V)     6
+         DC    A(X4,X4L,X4V,L'X4V)     7
+***********************************************************************
+*        Put new tests above this line
+***********************************************************************
+TN       EQU   *-16                Last test
+B1V      DC    C''
+B2V      DC    C'3'
+B3V      DC    C'*1'
+X1V      DC    C''
+X2V      DC    X'F3'
+X3V      DC    X'F1F2F3F4F5'
+X4V      DC    X'00F1F2'
+*
+         GBLC  &C
+         GBLA  &A
+***********************************************************************
+***      B2C('')
+&C       SETC B2C('')
+B1       DC    C'&C'               '' C''
+B1L      DC    AL4(L'B1)
+***      B2C('11110011')
+&C       SETC B2C('11110011')
+B2       DC    C'&C'               '11110011' C'3'
+B2L      DC    AL4(L'B2)
+*
+***      B2C('101110011110001')
+&C       SETC B2C('101110011110001')
+B3       DC    C'&C'               '101110011110001' C'*1'
+B3L      DC    AL4(L'B3)
+***********************************************************************
+***      X2C('')
+&C       SETC X2C('')
+X1       DC    C'&C'               '' C''
+X1L      DC    AL4(L'X1)
+*
+***      X2C('F3')
+&C       SETC X2C('F3')
+X2       DC    C'&C'               'F3' C'3'
+X2L      DC    AL4(L'X2)
+*
+***      X2C('F1F2F3F4F5')
+&C       SETC X2C('F1F2F3F4F5')
+X3       DC    C'&C'               'F1F2F3F4F5' C'12345'
+X3L      DC    AL4(L'X3)
+*
+***      X2C('0F1F2')
+&C       SETC X2C('0F1F2')
+X4       DC    C'&C'               '0F1F2' C'n12' n=X'00'
+X4L      DC    AL4(L'X4)
+***********************************************************************
+*
+         END
+

--- a/src/mz390.java
+++ b/src/mz390.java
@@ -443,6 +443,7 @@ public  class  mz390 {
 	 * 2022-08-22 #438 X2C issue
 	 * 2022-10-24 jjg #451 z390 ignores CODEPAGE option for input;
 	 *                     replace non-printable with '.' in PRN, BAL, PCH
+	 * 2023-04-12 #458 B2C issue; insure X2C length is multiple of 2
 	 ********************************************************
 	 * Global variables                       (last RPI)
 	 *****************************************************/
@@ -11899,13 +11900,20 @@ public  class  mz390 {
     	 * convert binary string to char string
     	 */
     	check_setc_quotes(1); // RPI 1139
-    	seta_value = Integer.valueOf(get_setc_stack_value(),2);
-		setc_value = ""
-			       + (char)tz390.ebcdic_to_ascii[seta_value >>> 24]
-			       + (char)tz390.ebcdic_to_ascii[seta_value >>> 16 & 0xff]         
-			       + (char)tz390.ebcdic_to_ascii[seta_value >>> 8  & 0xff]
-			       + (char)tz390.ebcdic_to_ascii[seta_value        & 0xff]					                               
-			       ;
+		setc_value1 = get_setc_stack_value();
+		int j = setc_value1.length();
+		if (j != 0)	{
+		    j = j % 8;
+		    if (j != 0) {
+		    	setc_value1 = "00000000".substring(0,8 - j)+setc_value1;
+	        }
+		}
+		StringBuilder stb = new StringBuilder("");
+		for (int i = 0; i < setc_value1.length(); i += 8) {
+		    String str = setc_value1.substring(i, i + 8);
+			stb.append((char)(((int)tz390.ebcdic_to_ascii[Integer.parseInt(str, 2)]) & 0xff));
+		}
+		setc_value = stb.toString();
 		put_setc_stack_var();
     }
     private void exec_pc_b2d(){
@@ -12329,6 +12337,8 @@ public  class  mz390 {
 		 */
 		check_setc_quotes(1); // RPI 1139
 		setc_value1 = get_setc_stack_value();
+		int j = setc_value1.length();
+		if (j != 0 && (j % 2) != 0) setc_value1 = "0"+setc_value1;
 		StringBuilder stb = new StringBuilder("");
 		for (int i = 0; i < setc_value1.length(); i += 2) {
 			String str = setc_value1.substring(i, i + 2);

--- a/z390test/src/test/groovy/org/z390/test/RunAsmTests.groovy
+++ b/z390test/src/test/groovy/org/z390/test/RunAsmTests.groovy
@@ -97,6 +97,12 @@ class RunAsmTests extends z390Test {
         assert rc == 0
     }
     @Test
+    void test_TB2CX2C() {
+        int rc = this.asmlg(basePath("rt", "mlc", "TB2CX2C"), *options, 'optable(z390)')
+        this.printOutput()
+        assert rc == 0
+    }
+    @Test
     void test_ZOPCHECK() {
         var syscpyOption = "SYSCPY(${basePath('zopcheck')}+${basePath('mac')})"
         this.env = ['SNAPOUT': basePath('zopcheck', 'SNAPOUT.TXT')]


### PR DESCRIPTION
Modify mz390.java B2C code for similar X2C problem previously fixed. Also modify X2C code to round number of bytes to a multiple of 2. Add test program TB2CX2C.MLC to test the changes.