### PR TITLE
Update z390test gradle wrapper to 8.2

### DIFF
--- a/z390test/gradle/wrapper/gradle-wrapper.properties
+++ b/z390test/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Required to allow rerun of tests using `gradlew test --rerun` command