### PR TITLE
IS#515 add trace command to display floating-point-control register

### DIFF
--- a/doc/user_guide/z390/commands.md
+++ b/doc/user_guide/z390/commands.md
@@ -78,10 +78,13 @@ The ez390 emulator supports the following interactive test commands when the
 * `addr=sdt` – set memory value  (i.e. 1r?=x'80' changes mem at (r1) 31 bit
 * `reg=sdt` - set register value (i.e. 15r=8 changes reg 15 to 8)
 * `A addr` – set or reset up to 100 instruction address stops with hex address or relative expression such as *+4
+* `AR nn` – display specified access register else all AR0-AR15
 * `B=addr` - set base for rel addr (ie B=15r% sets base to (r15) 24 bit
 * `D` – display DCB file information from TIOT
 * `E` – toggle between EBCDIC and ASCII mode
-* `F` – display floating point registers F0-FF
+* `F nn` – display floating point register else FPC and all F0-FF
+* `FPC` – display floating-point-control register
+* `FPC+` – display floating-point-control register in verbose mode
 * `G` - nn/addr/opcode - exec nn instr. or until specified instruction address or opcode is found with no trace.  One instruction is always executed before next opcode break even if it’s the same instruction such as a BCT 1,*.  Addresses are distinguished from count by hex . or relative expression term such as *, +, or -.
 * `H`  -  list help command summary
 * `J addr` -  jump to new addr and trace instruction
@@ -89,13 +92,16 @@ The ez390 emulator supports the following interactive test commands when the
 * `L reg` - list contents of register (ie l 1r dumps register 1
 * `L addr len` - list contents of memory area (ie l 10. 4 dumps cvt addr
 * `M` – display total memory in MB and total allocate and free bytes 
-    * `P` – display current loaded program information from CDE including name, entry and length
-    * `Q` - quit execution now
-    * `R` – display general purpose registers R0-RF
+* `P` – display current loaded program information from CDE including name, entry and length
+* `PSW` – display current PSW
+* `PSW+` – display current PSW in verbose mode
+* `PSW16` – display 16 byte current PSW
+* `Q` - quit execution now
+* `R nn` – display specified general purpose register else all R0-RF
 * `S`  - clear register, address, and memory breaks
 * `S reg??sdt`  - set break on register change
 * `S addr??sdt` - set break on memory change
-* `T nn/addr/opcode` - trace n instr. or until specified instruction address or opcode is found.  One instruction is always executed before next opcode break even if it’s the same instruction such as a BCT 1,*.  Addresses are distinguished from count by hex . or relative expression term such as *, +, or -.  The symbol EPA may be used in place of address to refer to last program load point address.
+* `T nn/addr/opcode` - trace nn instr. or until specified instruction address or opcode is found.  One instruction is always executed before next opcode break even if it’s the same instruction such as a BCT 1,*.  Addresses are distinguished from count by hex . or relative expression term such as *, +, or -.  The symbol EPA may be used in place of address to refer to last program load point address.
 * `V` - validate/verify
     * `V * nn` - validate nn bytes starting at PSW address
     * `V psw.subfield` - validate PSW subfield

--- a/doc/user_guide/z390/commands.md
+++ b/doc/user_guide/z390/commands.md
@@ -78,11 +78,11 @@ The ez390 emulator supports the following interactive test commands when the
 * `addr=sdt` – set memory value  (i.e. 1r?=x'80' changes mem at (r1) 31 bit
 * `reg=sdt` - set register value (i.e. 15r=8 changes reg 15 to 8)
 * `A addr` – set or reset up to 100 instruction address stops with hex address or relative expression such as *+4
-* `AR nn` – display specified access register else all AR0-AR15
+* `AR nn` – display specified access register else all AR 0-15
 * `B=addr` - set base for rel addr (ie B=15r% sets base to (r15) 24 bit
 * `D` – display DCB file information from TIOT
 * `E` – toggle between EBCDIC and ASCII mode
-* `F nn` – display floating point register else FPC and all F0-FF
+* `F nn` – display floating point register else FPC and all FPR 0-F
 * `FPC` – display floating-point-control register
 * `FPC+` – display floating-point-control register in verbose mode
 * `G` - nn/addr/opcode - exec nn instr. or until specified instruction address or opcode is found with no trace.  One instruction is always executed before next opcode break even if it’s the same instruction such as a BCT 1,*.  Addresses are distinguished from count by hex . or relative expression term such as *, +, or -.
@@ -97,7 +97,7 @@ The ez390 emulator supports the following interactive test commands when the
 * `PSW+` – display current PSW in verbose mode
 * `PSW16` – display 16 byte current PSW
 * `Q` - quit execution now
-* `R nn` – display specified general purpose register else all R0-RF
+* `R nn` – display specified general purpose register else all GPR 0-F
 * `S`  - clear register, address, and memory breaks
 * `S reg??sdt`  - set break on register change
 * `S addr??sdt` - set break on memory change

--- a/doc/user_guide/z390/commands.md
+++ b/doc/user_guide/z390/commands.md
@@ -82,7 +82,7 @@ The ez390 emulator supports the following interactive test commands when the
 * `B=addr` - set base for rel addr (ie B=15r% sets base to (r15) 24 bit
 * `D` – display DCB file information from TIOT
 * `E` – toggle between EBCDIC and ASCII mode
-* `F nn` – display floating point register else FPC and all FPR 0-F
+* `F nn` – display floating point register else FPC and all FPR 0-15
 * `FPC` – display floating-point-control register
 * `FPC+` – display floating-point-control register in verbose mode
 * `G` - nn/addr/opcode - exec nn instr. or until specified instruction address or opcode is found with no trace.  One instruction is always executed before next opcode break even if it’s the same instruction such as a BCT 1,*.  Addresses are distinguished from count by hex . or relative expression term such as *, +, or -.
@@ -97,7 +97,7 @@ The ez390 emulator supports the following interactive test commands when the
 * `PSW+` – display current PSW in verbose mode
 * `PSW16` – display 16 byte current PSW
 * `Q` - quit execution now
-* `R nn` – display specified general purpose register else all GPR 0-F
+* `R nn` – display specified general purpose register else all GPR 0-15
 * `S`  - clear register, address, and memory breaks
 * `S reg??sdt`  - set break on register change
 * `S addr??sdt` - set break on memory change

--- a/src/sz390.java
+++ b/src/sz390.java
@@ -6247,11 +6247,11 @@ private void exec_test_cmd(){
 	    tz390.put_trace("  addr=sdt    set memory value  (ie 1r?=x'80' changes mem at (r1) 31 bit");
 	    tz390.put_trace("  reg=sdt     set register value (ie 15r=8 changes reg 15 to 8)");
 	    tz390.put_trace("  A addr      add/remove address stop (ie A FF348. or A *+4 etc.)");  // RPI 395
-	    tz390.put_trace("  AR nn       display specified access register else all AR0-AR15");  // RPI 2000
+	    tz390.put_trace("  AR nn       display specified access register else all AR 0-15");  // RPI 2000 #515
 	    tz390.put_trace("  B=addr      set base for rel addr (ie B=15r% sets base to (r15) 24 bit");
 	    tz390.put_trace("  D           display DCB file status, DDNAME, and DSNAME information");
 	    tz390.put_trace("  E           toggle EBCDIC/ASCII mode for dumping storage etc.");
-	    tz390.put_trace("  F nn        display specified floating-point register else FPC and all F0-FF"); // #515
+	    tz390.put_trace("  F nn        display specified floating-point register else FPC & all FPR 0-F");  // #515
 	    tz390.put_trace("  FPC         display floating-point-control register");                           // #515
 	    tz390.put_trace("  FPC+        display floating-point-control register in verbose mode");           // #515
 	    tz390.put_trace("  G nn/adr/op exec n instr. or to hex addr or until next break without trace");
@@ -6263,7 +6263,7 @@ private void exec_test_cmd(){
         tz390.put_trace("  PSW         display current PSW");
         tz390.put_trace("  PSW+        display current PSW in verbose mode");
         tz390.put_trace("  PSW16       display 16 byte current PSW");                          // RPI 2008
-	    tz390.put_trace("  R nn        display specified general purpose register else all R0-RF");
+	    tz390.put_trace("  R nn        display specified general purpose register else all GPR 0-F");       // #515
 	    tz390.put_trace("  S           clear all breaks");
 	    tz390.put_trace("  S reg??sdt  set break on register change");
 	    tz390.put_trace("  S addr??sdt set break on memory change");

--- a/src/sz390.java
+++ b/src/sz390.java
@@ -6251,7 +6251,7 @@ private void exec_test_cmd(){
 	    tz390.put_trace("  B=addr      set base for rel addr (ie B=15r% sets base to (r15) 24 bit");
 	    tz390.put_trace("  D           display DCB file status, DDNAME, and DSNAME information");
 	    tz390.put_trace("  E           toggle EBCDIC/ASCII mode for dumping storage etc.");
-	    tz390.put_trace("  F nn        display specified floating-point register else FPC & all FPR 0-F");  // #515
+	    tz390.put_trace("  F nn        display specified floating-point register else FPC & all FPR 0-15"); // #515
 	    tz390.put_trace("  FPC         display floating-point-control register");                           // #515
 	    tz390.put_trace("  FPC+        display floating-point-control register in verbose mode");           // #515
 	    tz390.put_trace("  G nn/adr/op exec n instr. or to hex addr or until next break without trace");
@@ -6263,7 +6263,7 @@ private void exec_test_cmd(){
         tz390.put_trace("  PSW         display current PSW");
         tz390.put_trace("  PSW+        display current PSW in verbose mode");
         tz390.put_trace("  PSW16       display 16 byte current PSW");                          // RPI 2008
-	    tz390.put_trace("  R nn        display specified general purpose register else all GPR 0-F");       // #515
+	    tz390.put_trace("  R nn        display specified general purpose register else all GPR 0-15");      // #515
 	    tz390.put_trace("  S           clear all breaks");
 	    tz390.put_trace("  S reg??sdt  set break on register change");
 	    tz390.put_trace("  S addr??sdt set break on memory change");


### PR DESCRIPTION
The FPC and FPC+ commands are being added to the interactive trace command set. Also, SNAP and DUMP processing now displays the FPC (floating-point-control register) when displaying the floating-point registers.