### PR TITLE
is525 Register 14 not set for EODAD or SYNAD

### DIFF
--- a/bash/runasmdemos
+++ b/bash/runasmdemos
@@ -18,5 +18,29 @@ export SYSOUT=demo/TESTDCB1.TF3
 
 bash/asmlg demo/TESTDCB1 $1 $2 $3 $4 $5 $6 $7 $8 $9
 cat demo/TESTDCB1.TF2
+
+diff -q demo/TESTDCB1.TF1 demo/TESTDCB1.TF2 &>/dev/null
+rc1=$?
+if [ $rc1 -eq 0 ]; then x=""; else x=" not"; fi
+echo "TESTDCB1: Copy demo/TESTDCB1.TF1 to demo/TESTDCB1.TF2$x successful"
 echo "Verify demo/TESTDCB1 copied demo/TESTDCB1.TF1 to demo/TESTDCB1.TF2"
 echo "Verify demo/TESTDCB1 wrote to demo/TESTDCB1.TF3"
+
+export SYSUT1=demo/TESTDCB2.TF1
+export SYSUT2=demo/TESTDCB2.TF2
+export SYSOUT=demo/TESTDCB2.TF3
+
+bash/asmlg demo/TESTDCB2 $1 $2 $3 $4 $5 $6 $7 $8 $9
+cat demo/TESTDCB2.TF2
+diff -q demo/TESTDCB2.TF1 demo/TESTDCB2.TF2 &>/dev/null
+rc2=$?
+if [ $rc2 -eq 0 ]; then x=""; else x=" not"; fi
+echo "TESTDCB2: Copy demo/TESTDCB2.TF1 to demo/TESTDCB2.TF2$x successful"
+echo "Verify demo/TESTDCB2 copied demo/TESTDCB2.TF1 to demo/TESTDCB2.TF2"
+echo "Verify demo/TESTDCB2 wrote to demo/TESTDCB2.TF3"
+
+# return code is not zero if either diff return code is not zero
+rc=0
+if [ $rc1 -ne 0 ] || [ $rc2 -ne 0 ]; then rc=1; fi
+
+exit $rc

--- a/bat/RUNASMDEMOS.BAT
+++ b/bat/RUNASMDEMOS.BAT
@@ -29,6 +29,22 @@ call bat\ASMLG %z_TraceMode% demo\TESTDCB1 %1 %2 %3 %4 %5 %6 %7 %8 %9 || goto er
 :: type demo\TESTDCB1.TF2
 :: echo "Verify demo\TESTDCB1 copied demo\TESTDCB1.TF1 to demo\TESTDCB1.TF2"
 :: echo "Verify demo\TESTDCB1 wrote to demo\TESTDCB1.TF3"
+
+set sysut1=demo\TESTDCB2.TF1
+set sysut2=demo\TESTDCB2.TF2
+set sysout=demo\TESTDCB2.TF3
+call bat\ASMLG %z_TraceMode% demo\TESTDCB2 %1 %2 %3 %4 %5 %6 %7 %8 %9 || goto error
+::comp /M demo\TESTDCB2.TF1 demo\TESTDCB2.TF2
+::set z_ReturnCode=%ERRORLEVEL%
+::if %z_ReturnCode% GTR 0 (set z_ReturnCode=8
+::                         echo %0 ERROR: TESTDCB2 data were not copied correctly
+::                         goto return
+::
+::                         )
+:: next 4 lines added to temporarily match bash version
+:: type demo\TESTDCB2.TF2
+:: echo "Verify demo\TESTDCB2 copied demo\TESTDCB2.TF1 to demo\TESTDCB1.TF2"
+:: echo "Verify demo\TESTDCB2 wrote to demo\TESTDCB2.TF3"
 set z_ReturnCode=0
 goto return
 

--- a/demo/TESTDCB2.MLC
+++ b/demo/TESTDCB2.MLC
@@ -1,6 +1,6 @@
 *********************************************************************
 * z390 - Mainframe assembler emulator and run-time engine
-* Copyright (C) 2021 z390 Assembler LLC
+* Copyright (C) 2024 z390 Assembler LLC
 *
 * This file is part of z390.
 *
@@ -16,7 +16,7 @@
 * You should have received a copy of the GNU General Public License 
 * along with this program; if not, see https://www.gnu.org/licenses.
 
-* Author - Don Higgins                                              *
+* Author - Don Higgins and John Ganci                               *
 * Date   - 06/04/2024                                               *
 *********************************************************************
 * Same as demo/TESTDCB1 but illustrates EODAD that returns to GET
@@ -26,8 +26,8 @@ TESTDCB2 SUBENTRY
          WTO   'TESTDCB2 Copy SYSUT1 ASC test file to SYSUT2 ASC text'
          OPEN  MF=(E,OFILES)       Open all files
          MVI   EOFFLAG,C'N'        Set not EOF on input file
-         GET   SYSUT1,RECORD       Get first record
 LOOP     DS    0H
+         GET   SYSUT1,RECORD       Get next/first record
          CLI   EOFFLAG,C'Y'        No more records?
          BE    ELOOP               Yes: all done
          AP    PTOT,=P'1'          Count records
@@ -35,7 +35,6 @@ LOOP     DS    0H
          ED    DTOT,PTOT           ... to printable decimal 
          PUT   SYSOUT,MSG          Put rec# || record
          PUT   SYSUT2,RECORD       Put record
-         GET   SYSUT1,RECORD       Next record
          B     LOOP
 ELOOP    DS    0H
          CLOSE MF=(E,CFILES)

--- a/demo/TESTDCB2.MLC
+++ b/demo/TESTDCB2.MLC
@@ -1,0 +1,64 @@
+*********************************************************************
+* z390 - Mainframe assembler emulator and run-time engine
+* Copyright (C) 2021 z390 Assembler LLC
+*
+* This file is part of z390.
+*
+* z390 is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 2 of the License, or
+* (at your option) any later version.
+* z390 is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License 
+* along with this program; if not, see https://www.gnu.org/licenses.
+
+* Author - Don Higgins                                              *
+* Date   - 06/04/2024                                               *
+*********************************************************************
+* Same as demo/TESTDCB1 but illustrates EODAD that returns to GET
+*********************************************************************
+*
+TESTDCB2 SUBENTRY
+         WTO   'TESTDCB2 Copy SYSUT1 ASC test file to SYSUT2 ASC text'
+         OPEN  MF=(E,OFILES)       Open all files
+         MVI   EOFFLAG,C'N'        Set not EOF on input file
+         GET   SYSUT1,RECORD       Get first record
+LOOP     DS    0H
+         CLI   EOFFLAG,C'Y'        No more records?
+         BE    ELOOP               Yes: all done
+         AP    PTOT,=P'1'          Count records
+         MVC   DTOT,=X'40202020'   Convert record count
+         ED    DTOT,PTOT           ... to printable decimal 
+         PUT   SYSOUT,MSG          Put rec# || record
+         PUT   SYSUT2,RECORD       Put record
+         GET   SYSUT1,RECORD       Next record
+         B     LOOP
+ELOOP    DS    0H
+         CLOSE MF=(E,CFILES)
+         WTO   'TESTDCB2 Ended OK'
+         SUBEXIT
+***********************************************************************
+*        EODAD routine
+***********************************************************************
+EOF      DS    0H
+         MVI   EOFFLAG,C'Y'        Set end of file reached on input
+         BR    14                  Return to GET
+*
+OFILES   OPEN  MF=L,(SYSUT1,INPUT,SYSUT2,OUTPUT,SYSOUT,OUTPUT)
+CFILES   CLOSE MF=L,(SYSUT1,,SYSUT2,,SYSOUT)
+SYSUT1   DCB   DDNAME=SYSUT1,RECFM=FT,LRECL=80,EODAD=EOF,MACRF=GM
+SYSUT2   DCB   DDNAME=SYSUT2,RECFM=FT,LRECL=80,MACRF=PM
+SYSOUT   DCB   DDNAME=SYSOUT,RECFM=FT,BLKSIZE=120,MACRF=PM
+EOFFLAG  DS    CL1                 Set to C'Y' when EOF on input file
+PTOT     DC    PL2'0'
+MSG      DS    0CL120
+         DC    C'REC#='
+DTOT     DC    CL4' ',C' TEXT='
+RECORD   DC    CL80' '
+         DC    (MSG+120-*)C' '
+         DCBD
+         END

--- a/demo/TESTDCB2.MLC
+++ b/demo/TESTDCB2.MLC
@@ -28,6 +28,7 @@ TESTDCB2 SUBENTRY
          MVI   EOFFLAG,C'N'        Set not EOF on input file
 LOOP     DS    0H
          GET   SYSUT1,RECORD       Get next/first record
+AFTERGET DS    0H
          CLI   EOFFLAG,C'Y'        No more records?
          BE    ELOOP               Yes: all done
          AP    PTOT,=P'1'          Count records
@@ -45,8 +46,11 @@ ELOOP    DS    0H
 ***********************************************************************
 EOF      DS    0H
          MVI   EOFFLAG,C'Y'        Set end of file reached on input
-         BR    14                  Return to GET
+         C     14,@AFTERGET        Belt and suspenders test
+         BER   14                  Return to GET
+         DC    H'0'                Should not get here!
 *
+@AFTERGET DC   A(AFTERGET)         For belt and suspenders R14 test
 OFILES   OPEN  MF=L,(SYSUT1,INPUT,SYSUT2,OUTPUT,SYSOUT,OUTPUT)
 CFILES   CLOSE MF=L,(SYSUT1,,SYSUT2,,SYSOUT)
 SYSUT1   DCB   DDNAME=SYSUT1,RECFM=FT,LRECL=80,EODAD=EOF,MACRF=GM

--- a/demo/TESTDCB2.TF1
+++ b/demo/TESTDCB2.TF1
@@ -1,0 +1,3 @@
+record 1 of 3
+record 2 of 3 longer
+record 3 of 3 longest

--- a/demo/TESTDCB2.TF2
+++ b/demo/TESTDCB2.TF2
@@ -1,0 +1,3 @@
+record 1 of 3
+record 2 of 3 longer
+record 3 of 3 longest

--- a/demo/TESTDCB2.TF3
+++ b/demo/TESTDCB2.TF3
@@ -1,0 +1,3 @@
+REC#=   1 TEXT=record 1 of 3
+REC#=   2 TEXT=record 2 of 3 longer
+REC#=   3 TEXT=record 3 of 3 longest

--- a/src/sz390.java
+++ b/src/sz390.java
@@ -227,6 +227,10 @@ public  class  sz390 implements Runnable {
     * 2023-08-07 Issue #515. Display FPC contents in interactive debug mode
     *            and when displaying floating-point registers in SNAP or DUMP.
     ^ 2024-02-26 Issue #463 Add missing subscript to cmd_read_line reference
+	* 2024-06-04 Issue #525. DCB or DCBE EODAD routine setup in dcb_eodad_exit()
+	*            does not set R14 as a return address for GET or CHECK (READ/CHECK).
+	*            Similarly, DCB or DCBE SYNAD routine setup in dcb_synad_exit() does
+	*            not set R14 as a return address for GET or CHECK (READ/CHECK).
 	********************************************************
     * Global variables                   (last RPI)
     *****************************************************/
@@ -4177,6 +4181,7 @@ private void dcb_synad_error(int error_num,String error_msg){
 		log_error(error_num,error_msg);
 		pz390.set_psw_check(pz390.psw_pic_io); //RPI64
 	} else {
+		pz390.reg.putInt((14<<3)+4,pz390.psw_loc);  // #525
 		pz390.set_psw_loc(cur_dcb_synad);
 	}
 	dcb_synad_recur = false; // RPI 377
@@ -4195,6 +4200,7 @@ private void dcb_eodad_exit(){
 	if (cur_dcb_eodad == 0){
 		abort_error(31,"read at end of file and no EODAD for " + tiot_ddnam[cur_tiot_index]);
 	} else {
+		pz390.reg.putInt((14<<3)+4,pz390.psw_loc);  // #525
 		pz390.set_psw_loc(cur_dcb_eodad);
 	}
 }

--- a/z390test/src/test/groovy/org/z390/test/RunAsmDemos.groovy
+++ b/z390test/src/test/groovy/org/z390/test/RunAsmDemos.groovy
@@ -36,5 +36,23 @@ class RunAsmDemos extends z390Test {
         assert fileData.get('TF1') == fileData.get('TF2')
         assert rc == 0
     }
+    @Test
+    void test_TESTDCB2() {
+        // Set input files
+        env.put('SYSUT1', basePath('demo', 'TESTDCB2.TF1'))
+        env.put('SYSUT2', basePath('demo', 'TESTDCB2.TF2'))
+        env.put('SYSOUT', basePath('demo', 'TESTDCB2.TF3'))
+        // run the job
+        int rc = this.asmlg(basePath("demo", "TESTDCB2"), *options)
+        // Load files to fileData
+        loadFile(basePath('demo', 'TESTDCB2.TF1'), 'TF1')
+        loadFile(basePath('demo', 'TESTDCB2.TF2'), 'TF2')
+        loadFile(basePath('demo', 'TESTDCB2.TF3'), 'SYSOUT')
+        // print the fileData
+        this.printOutput()
+        // Check files equal
+        assert fileData.get('TF1') == fileData.get('TF2')
+        assert rc == 0
+    }
 
 }


### PR DESCRIPTION
IBM documentation states that upon entry to either an EODAD or SYNAD exit for QSAM or BSAM, register 14 contains the address of the instruction following a GET (QSAM) or CHECK (BSAM). The z390 code in sz390.java did not set register 14 when processing a GET or CHECK that resulted in EODAD or SYNAD being invoked. Code has been added to sz390 to do so. In addition, a new test program, demo/TESTDCB2.MLC (a modified version of demo/TESTDCB1.MLC), has been added to the test suite that has an EODAD return point that uses the register 14 value to return to the GET that resulted in end of input.