### PR TITLE
Is509 correct errors in z390 implementation of  HLASM built-in functions

### DIFF
--- a/rt/bash/errora2btests
+++ b/rt/bash/errora2btests
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# errora2btests: regression test A2B error
+
+# global variable containing name of script; used by error function
+scriptName="errora2btests"
+
+########################################
+# print error message and exit
+#
+# input:
+#   $1 name of program for the error
+#   $2 program expected return code
+#   $3 program actual return code
+########################################
+
+function error {
+    echo "$scriptName ERROR: $1 expected RC=$2 but actual RC=$3; exiting"
+    exit 8
+}
+
+#set -e             # exit on all errors; not for this script
+cd $(dirname $0)    # set to directory of script - rt/bash
+cd ..               # up to rt
+cd ..               # up to z390
+
+prog="A2BE1"
+bash/asm rt/mlc/$prog
+rc=$?
+if [ $rc -ne 12 ]; then error "$prog" 12 $rc; fi
+
+prog="A2BE2"
+bash/asm rt/mlc/$prog
+rc=$?
+if [ $rc -ne 12 ]; then error "$prog" 12 $rc; fi
+
+# if we get here, there were no errors
+rc=0
+echo "$scriptName exiting with RC=$rc"
+exit $rc

--- a/rt/bash/errorisbintests
+++ b/rt/bash/errorisbintests
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# errorisbintests: regression test ISBIN error
+
+# global variable containing name of script; used by error function
+scriptName="errorisbintests"
+
+########################################
+# print error message and exit
+#
+# input:
+#   $1 name of program for the error
+#   $2 program expected return code
+#   $3 program actual return code
+########################################
+
+function error {
+    echo "$scriptName ERROR: $1 expected RC=$2 but actual RC=$3; exiting"
+    exit 8
+}
+
+
+#set -e             # exit on all errors; not for this script
+cd $(dirname $0)    # set to directory of script - rt/bash
+cd ..               # up to rt
+cd ..               # up to z390
+
+prog="ISBINE1"
+bash/asm rt/mlc/$prog
+rc=$?
+if [ $rc -ne 8 ]; then error "$prog" 8 $rc; fi
+
+# if we get here, there were no errors
+rc=0
+echo "$scriptName exiting with RC=$rc"
+exit $rc

--- a/rt/bash/errorisdectests
+++ b/rt/bash/errorisdectests
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# errorisdectests: regression test ISDEC error
+
+# global variable containing name of script; used by error function
+scriptName="errorisdectests"
+
+########################################
+# print error message and exit
+#
+# input:
+#   $1 name of program for the error
+#   $2 program expected return code
+#   $3 program actual return code
+########################################
+
+function error {
+    echo "$scriptName ERROR: $1 expected RC=$2 but actual RC=$3; exiting"
+    exit 8
+}
+
+#set -e             # exit on all errors; not for this script
+cd $(dirname $0)    # set to directory of script - rt/bash
+cd ..               # up to rt
+cd ..               # up to z390
+
+prog="ISDECE1"
+bash/asm rt/mlc/$prog
+rc=$?
+if [ $rc -ne 8 ]; then error "$prog" 8 $rc; fi
+
+# if we get here, there were no errors
+rc=0
+echo "$scriptName exiting with RC=$rc"
+exit $rc

--- a/rt/bash/errorishextests
+++ b/rt/bash/errorishextests
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# errorishextests: regression test ISHEX error
+
+# global variable containing name of script; used by error function
+scriptName="errorishextests"
+
+########################################
+# print error message and exit
+#
+# input:
+#   $1 name of program for the error
+#   $2 program expected return code
+#   $3 program actual return code
+########################################
+
+function error {
+    echo "$scriptName ERROR: $1 expected RC=$2 but actual RC=$3; exiting"
+    exit 8
+}
+
+#set -e             # exit on all errors; not for this script
+cd $(dirname $0)    # set to directory of script - rt/bash
+cd ..               # up to rt
+cd ..               # up to z390
+
+prog="ISHEXE1"
+bash/asm rt/mlc/$prog
+rc=$?
+if [ $rc -ne 8 ]; then error "$prog" 8 $rc; fi
+
+# if we get here, there were no errors
+rc=0
+echo "$scriptName exiting with RC=$rc"
+exit $rc

--- a/rt/bash/errorissymtests
+++ b/rt/bash/errorissymtests
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# errorissymtests: regression test ISSYM error
+
+# global variable containing name of script; used by error function
+scriptName="errorissymtests"
+
+########################################
+# print error message and exit
+#
+# input:
+#   $1 name of program for the error
+#   $2 program expected return code
+#   $3 program actual return code
+########################################
+
+function error {
+    echo "$scriptName ERROR: $1 expected RC=$2 but actual RC=$3; exiting"
+    exit 8
+}
+
+#set -e             # exit on all errors; not for this script
+cd $(dirname $0)    # set to directory of script - rt/bash
+cd ..               # up to rt
+cd ..               # up to z390
+
+prog="ISSYME1"
+bash/asm rt/mlc/$prog
+rc=$?
+if [ $rc -ne 8 ]; then error "$prog" 8 $rc; fi
+
+# if we get here, there were no errors
+rc=0
+echo "$scriptName exiting with RC=$rc"
+exit $rc

--- a/rt/bash/errorslatests
+++ b/rt/bash/errorslatests
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# errorslatests: regression test SLA errors
+
+# global variable containing name of script; used by error function
+scriptName="errorslatests"
+
+########################################
+# print error message and exit
+#
+# input:
+#   $1 name of program for the error
+#   $2 program expected return code
+#   $3 program actual return code
+########################################
+
+function error {
+    echo "$scriptName ERROR: $1 expected RC=$2 but actual RC=$3; exiting"
+    exit 8
+}
+
+#set -e             # exit on all errors; not for this script
+cd $(dirname $0)    # set to directory of script - rt/bash
+cd ..               # up to rt
+cd ..               # up to z390
+
+prog="SLAE1"
+bash/asm rt/mlc/$prog
+rc=$?
+if [ $rc -ne 8 ]; then error "$prog" 8 $rc; fi
+
+# if we get here, there were no errors
+rc=0
+echo "$scriptName exiting with RC=$rc"
+exit $rc

--- a/rt/bash/readme.txt
+++ b/rt/bash/readme.txt
@@ -14,5 +14,6 @@ runtbrctx   - verify closed issue #238
 runtestopt  - verify indirection usage in options files
 runbr14owe  - verifies test IEFBR14 asm[l[g]] with Okay, Warning, Error variants
 runcodepagetests - verifies usage of CODEPAGE issue #451
+runhlasmbiftests - verifies HLASM built-in functions issue #509
 
 End regression test commands

--- a/rt/bash/readme.txt
+++ b/rt/bash/readme.txt
@@ -14,6 +14,13 @@ runtbrctx   - verify closed issue #238
 runtestopt  - verify indirection usage in options files
 runbr14owe  - verifies test IEFBR14 asm[l[g]] with Okay, Warning, Error variants
 runcodepagetests - verifies usage of CODEPAGE issue #451
-runhlasmbiftests - verifies HLASM built-in functions issue #509
+runhlasmbiftests - run HLASM built-in function tests issue 509
+errora2btests    - verify A2B  error tests
+errorisbintests  - verify ISBIN error tests
+errorisdectests  - verify ISDEC error tests
+errorishextests  - verify ISHEX error tests
+errorissymtests  - verify ISSYM error tests
+errorslatests    - verify SLA error tests
+x00c2bdxtests    - verify C2B, C2D, C2X tests that have X'00' in argument
 
 End regression test commands

--- a/rt/bash/runhlasmbiftests
+++ b/rt/bash/runhlasmbiftests
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# runhlasmbiftests: regression test HLASM built-in functions
+
+set -e              # exit on all errors
+cd $(dirname $0)    # set to directory of script - rt/bash
+cd ..               # up to rt
+cd ..               # up to z390
+
+sysmac='sysmac(mac)'
+optable='optable(z390)'
+
+dir1="rt/test"
+dir2="rt/mlc"
+
+bash/asmlg ${dir1}/TESTOPR2 trace noloadhigh noinit $sysmac
+
+export REPORT=${dir2}/TOPR2.TXT
+bash/asmlg ${dir2}/TOPR2 trace noloadhigh noinit $sysmac
+
+# if we get here, there were no errors
+echo "Verify tests ran without errors"
+echo "  View ${dir1}/TESTOPR2.PRN to see tests checked with MNOTE,AIF"
+echo "  View ${dir2}/TOPR2.TXT to see tests checked with code"
+exit 0

--- a/rt/bash/runhlasmbiftests
+++ b/rt/bash/runhlasmbiftests
@@ -15,7 +15,7 @@ dir2="rt/mlc"
 
 bash/asmlg ${dir1}/TESTOPR2 trace noloadhigh noinit $sysmac
 
-export REPORT=${dir2}/TOPR2.TXT
+export REPORT=${dir2}/TOPR2.TST
 bash/asmlg ${dir2}/TOPR2 trace noloadhigh noinit $sysmac
 
 # if we get here, there were no errors

--- a/rt/bash/x00c2bdxtests
+++ b/rt/bash/x00c2bdxtests
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# x00c2bdxtests: regression test HLASM built-in functions
+
+set -e              # exit on all errors
+cd $(dirname $0)    # set to directory of script
+cd ../..            # up two directories; the z390 directory
+
+sysmac='sysmac(mac)'
+
+# assemble test program
+bash/asm rt/mlc/C2BDX00 trace noloadhigh $sysmac
+rc=$?
+if [ $rc -ne 0 ]; then
+    echo "Error assembling test program; rc=$rc"
+    exit $rc
+fi
+
+# if we get here, there were no errors
+echo "Verify tests ran without errors"
+echo "  View rt/mlc/C2BDX00.PRN to see tests"
+exit 0

--- a/rt/mlc/A2BE1.MLC
+++ b/rt/mlc/A2BE1.MLC
@@ -1,0 +1,20 @@
+* Test A2B built-in function error
+A2BE1    CSECT
+         SR    15,15
+         BR    14
+*
+         LCLC  &C
+*
+*        HLASM LangRef example
+*
+*&C      SETC  'abc'               Preset result field
+&C       SETC  'abc'
+*
+*&C      SETC  A2B(2345678901)     Error; too large
+&C       SETC  A2B(2345678901)
+         MNOTE 'A2B(2345678901)=&C'
+         AIF   ('&C' EQ 'abc').OK
+         MNOTE 12.'Error; expected value is abc'
+.OK      ANOP
+*        
+         END

--- a/rt/mlc/A2BE2.MLC
+++ b/rt/mlc/A2BE2.MLC
@@ -1,0 +1,20 @@
+* Test A2B built-in function error
+A2BE2    CSECT
+         SR    15,15
+         BR    14
+*
+         LCLC  &C
+*
+*        z390 example
+*
+*&C      SETC  'abc'               Preset result field
+&C       SETC  'abc'
+*
+*&C      SETC  A2B(--2147483648)   Error; overflow
+&C       SETC  A2B(--2147483648)
+         MNOTE 'A2B(--2147483648)=&C'
+         AIF   ('&C' EQ 'abc').OK
+         MNOTE 12.'Error; expected value is abc'
+.OK      ANOP
+*
+         END

--- a/rt/mlc/C2BDX00.MLC
+++ b/rt/mlc/C2BDX00.MLC
@@ -1,0 +1,34 @@
+* Test HLASM built-in functions that have X'00' in argument string
+C2BDX00  CSECT
+         LCLC  &C2B,&C2D,&C2X
+*
+         LCLC  &NULL,&NULLj
+*
+*        &NULL,&NULLj values taken from HLASM LangRef B2C examples
+&NULL    SETC  B2C('0')    value 'n' = null char = X'00'
+&NULLj   SETC  '&NULL'.'j' value 'nj'
+*
+*        HLASM LangRef examples
+*
+*&C2B    SETC  C2B('n')    n = null char = X'00'
+&C2B     SETC  C2B('&NULL')
+         MNOTE 'C2B(''&NULL'')=&C2B'
+         AIF   ('&C2B' EQ '00000000').OKC2B
+         MNOTE 8,'C2B: Generated value not equal to expected value'
+.OKC2B   ANOP
+*
+*&C2D    SETC  C2D('nj')   n = null char = X'00'
+&C2D     SETC  C2D('&NULLj')
+         MNOTE 'C2D(''&NULLj'')=&C2D'
+         AIF   ('&C2D' EQ '+145').OKC2D
+         MNOTE 8,'C2D: Generated value not equal to expected value'
+.OKC2D   ANOP
+*
+*&C2X    SETC  C2X('n')    n = null char = X'00'
+&C2X     SETC  C2X('&NULL')
+         MNOTE 'C2X(''&NULL'')=&C2X'
+         AIF   ('&C2X' EQ '00').OKC2X
+         MNOTE 8,'C2X: Generated value not equal to expected value'
+.OKC2X   ANOP
+*
+         END

--- a/rt/mlc/ISBINE1.MLC
+++ b/rt/mlc/ISBINE1.MLC
@@ -1,0 +1,20 @@
+* Test ISBIN built-in function error
+ISBINE1  CSECT
+         SR    15,15
+         BR    14
+*
+         LCLA  &A 
+*
+*        HLASM LangRef example
+*
+*&A      SETA  123                 Preset return value
+&A       SETA  123
+*&A      ISBIN('')                 Error
+&A       SETA  ISBIN('')           0
+         MNOTE 'ISBIN('''')=&A'
+         DC    F'&A'
+         AIF   (&A EQ 0).OK
+         MNOTE 12,'Error; expected value is 0'
+.OK      ANOP
+*
+         END 

--- a/rt/mlc/ISDECE1.MLC
+++ b/rt/mlc/ISDECE1.MLC
@@ -1,0 +1,20 @@
+* Test ISDEC built-in function error
+ISDECE1  CSECT
+         SR    15,15
+         BR    14
+*
+         LCLA  &A 
+*
+*        HLASM LangRef example
+*
+*&A      SETA  123                 Preset return value
+&A       SETA  123
+*&A      ISDEC('')                 Error
+&A       SETA  ISDEC('')           0
+         MNOTE 'ISDEC('''')=&A'
+         DC    F'&A'
+         AIF   (&A EQ 0).OK
+         MNOTE 12,'Error; expected value is 0'
+.OK      ANOP
+*
+         END 

--- a/rt/mlc/ISHEXE1.MLC
+++ b/rt/mlc/ISHEXE1.MLC
@@ -1,0 +1,20 @@
+* Test ISHEX built-in function error
+ISHEXE1  CSECT
+         SR    15,15
+         BR    14
+*
+         LCLA  &A 
+*
+*        HLASM LangRef example
+*
+*&A      SETA  123                 Preset return value
+&A       SETA  123
+*&A      ISHEX('')                 Error
+&A       SETA  ISHEX('')           0
+         MNOTE 'ISHEX('''')=&A'
+         DC    F'&A'
+         AIF   (&A EQ 0).OK
+         MNOTE 12,'Error; expected value is 0'
+.OK      ANOP
+*
+         END 

--- a/rt/mlc/ISSYME1.MLC
+++ b/rt/mlc/ISSYME1.MLC
@@ -1,0 +1,20 @@
+* Test ISSYM built-in function error
+ISSYME1  CSECT
+         SR    15,15
+         BR    14
+*
+         LCLA  &A 
+*
+*        HLASM LangRef example
+*
+*&A      SETA  123                 Preset return value
+&A       SETA  123
+*&A      ISSYM('')                 Error
+&A       SETA  ISSYM('')           0
+         MNOTE 'ISSYM('''')=&A'
+         DC    F'&A'
+         AIF   (&A EQ 0).OK
+         MNOTE 12,'Error; expected value is 0'
+.OK      ANOP
+*
+         END 

--- a/rt/mlc/SLAE1.MLC
+++ b/rt/mlc/SLAE1.MLC
@@ -1,0 +1,192 @@
+* Test SLA built-in function error
+*
+***********************************************************************
+*        Macro to show operands and result of
+*            &SLA SETA (&OP1 SLA &OP2)
+*        in binary, hexadecimal, and signed decimal
+*
+*        Sample output
+*            &OP1     SETA  16+1
+*            &OP2     SETA  31-5
+*            &SLA     SETA  (&OP1 SLA &OP2)  valid; shifts 1 into bit 1
+*                     SHOWSBC
+*          +    MNOTE '(X'00000011' SLA 26) = 1140850688 (X'44000000')'
+*          +    MNOTE 'Binary OP1 00000000000000000000000000010001'
+*          +    MNOTE 'Binary OP2 00000000000000000000000000011010'
+*          +    MNOTE 'Binary SLA 01000100000000000000000000000000'
+***********************************************************************
+*
+         MACRO
+         SHOWSBC
+         GBLA  &OP1,&OP2,&SLA
+         LCLC  &SOP1,&SOP2,&SSLA
+         LCLC  &BOP1,&BOP2,&BSLA
+         LCLC  &XOP1,&XOP2,&XSLA
+.*
+&SSLA    SETC  (SIGNED &SLA)
+&BSLA    SETC  A2B(&SLA)
+&XSLA    SETC  A2X(&SLA)
+.*
+&SOP1    SETC  SIGNED(&OP1)
+&BOP1    SETC  A2B(&OP1)
+&XOP1    SETC  A2X(&OP1)
+.*
+&SOP2    SETC  (SIGNED &OP2)
+&BOP2    SETC  A2B(&OP2)
+&XOP2    SETC  A2X(&OP2)
+.*
+         MNOTE '(X''&XOP1'' SLA &SOP2) = &SSLA (X''&XSLA'')'
+         MNOTE 'Binary OP1 &BOP1'
+         MNOTE 'Binary OP2 &BOP2'
+         MNOTE 'Binary SLA &BSLA'
+.*
+         MEND
+***********************************************************************
+         GBLA  &OP1,&OP2,&SLA
+*
+*        Show SLA results
+*
+*        GBLA &OP1,&OP2,&SLA preset via "&SLA SETA (&OP1 SLA &OP2)"
+*
+***********************************************************************
+SLAE1    CSECT
+         SR    15,15
+         BR    14
+*
+         LCLA  &A 
+*
+*        z390 examples
+*
+***********************************************************************
+&OP1     SETA  1
+&OP2     SETA  -1
+&SLA     SETA  2
+*&OP1    SETA  1
+*&OP2    SETA  -1
+*&SLA    SETA  2                       Preset result
+*&SLA    SETA  (&OP1 SLA &OP2)         Invalid; shifts >= 32 bits
+&SLA     SETA  (&OP1 SLA &OP2)
+         SHOWSBC
+         AIF   (&SLA EQ 0).OK1         Expected value?
+         MNOTE 12,'Expected value is 0'
+.OK1     ANOP
+***********************************************************************
+&OP1     SETA  1
+&OP2     SETA  63
+&SLA     SETA  2
+*&OP1    SETA  1
+*&OP2    SETA  63
+*&SLA    SETA  2                       Preset result
+**SLA    SETA  (&OP1 SLA &OP2)         Invalid; shifts >- 32 bits
+&SLA     SETA  (&OP1 SLA &OP2)
+         SHOWSBC
+         AIF   (&SLA EQ 0).OK2         Expected value?
+         MNOTE 12,'Expected value is 0'
+.OK2     ANOP
+***********************************************************************
+&OP1     SETA  2147483647
+&OP2     SETA  1
+&SLA     SETA  2
+*&OP1    SETA  2147483647
+*&OP2    SETA  1
+*&SLA    SETA  2                       Preset result
+*&SLA    SETA  (&OP1 SLA &OP2)         Invalid; shifts 1 into sign bit
+&SLA     SETA  (&OP1 SLA &OP2)
+         SHOWSBC
+         AIF   (&SLA EQ 0).OK3         Expected value?
+         MNOTE 12,'Expected value is 0'
+.OK3     ANOP
+***********************************************************************
+&OP1     SETA  1
+&OP2     SETA  31
+&SLA     SETA  2
+*&OP1    SETA  1
+*&OP2    SETA  31
+*&SLA    SETA  2                       Preset result
+**SLA    SETA  (&OP1 SLA &OP2)         Invalid; shifts 11 into sign bit
+&SLA     SETA  (&OP1 SLA &OP2)
+         SHOWSBC
+         AIF   (&SLA EQ 0).OK4         Expected value?
+         MNOTE 12,'Expected value is 0'
+.OK4     ANOP
+***********************************************************************
+&OP1     SETA  -1
+&OP2     SETA  32
+&SLA     SETA  2
+*&OP1    SETA  -1
+*&OP2    SETA  32
+*&SLA    SETA  2                       Preset result
+*&SLA    SETA  (&OP1 SLA &OP2)         Invalid; non-zero; >=32 bits
+&SLA     SETA  (&OP1 SLA &OP2)
+         SHOWSBC
+         AIF   (&SLA EQ 0).OK5         Expected value?
+         MNOTE 12,'Expected value is 0'
+.OK5     ANOP
+***********************************************************************
+&OP1     SETA  -2147483647
+&OP2     SETA  1
+&SLA     SETA  2
+*&OP1    SETA  -2147483647
+*&OP2    SETA  1
+*&SLA    SETA  2                       Preset result
+*&SLA    SETA  (&OP1 SLA &OP2)         invalid; shifts 0 to sign bit
+&SLA     SETA  (&OP1 SLA &OP2)
+         SHOWSBC
+         AIF   (&SLA EQ 0).OK6         Expected value?
+         MNOTE 12,'Expected value is 0'
+.OK6     ANOP
+***********************************************************************
+&OP1     SETA  -2147483647
+&OP2     SETA  32
+&SLA     SETA  2
+*&OP1    SETA  -2147483647
+*&OP2    SETA  32
+*&SLA    SETA  2                       Preset result
+*&SLA    SETA  (&OP1 SLA &OP2)         Invalid; non-zero >=32 bits
+&SLA     SETA  (&OP1 SLA &OP2)
+         SHOWSBC
+         AIF   (&SLA EQ 0).OK7         Expected value?
+         MNOTE 12,'Expected value is 0'
+.OK7     ANOP
+***********************************************************************
+&OP1     SETA  -2147483648
+&OP2     SETA  1
+&SLA     SETA  2
+*&OP1    SETA  -2147483648
+*&OP2    SETA  1
+*&SLA    SETA  2                       Preset result
+*&SLA    SETA  (&OP1 SLA &OP2)         Invalid; shift 0 int sign bit
+&SLA     SETA  (&OP1 SLA &OP2)
+         SHOWSBC
+         AIF   (&SLA EQ 0).OK8         Expected value?
+         MNOTE 12,'Expected value is 0'
+.OK8     ANOP
+***********************************************************************
+&OP1     SETA  16+1
+&OP2     SETA  31-4
+&SLA     SETA  2
+*&OP1    SETA  16+1
+*&OP2    SETA  31-4
+*&SLA    SETA  2                       Preset result
+*&SLA    SETA  (&OP1 SLA &OP2)         invalid; shifts 1 into sign bit
+&SLA     SETA  (&OP1 SLA &OP2)
+         SHOWSBC
+         AIF   (&SLA EQ 0).OK9         Expected value?
+         MNOTE 12,'Expected value is 0'
+.OK9     ANOP
+***********************************************************************
+&OP1     SETA  -16-1
+&OP2     SETA  31-4
+&SLA     SETA  2
+*&OP1    SETA  -16-1
+*&OP2    SETA  31-4
+*&SLA    SETA  2                       Preset result
+*&SLA    SETA  (&OP1 SLA &OP2)         invalid; shifts 0 into sigh bit
+&SLA     SETA  (&OP1 SLA &OP2)
+         SHOWSBC
+         AIF   (&SLA EQ 0).OK10        Expected value?
+         MNOTE 12,'Expected value is 0'
+.OK10    ANOP
+***********************************************************************
+*
+         END

--- a/rt/mlc/TESTASC1.MLC
+++ b/rt/mlc/TESTASC1.MLC
@@ -50,6 +50,7 @@
 * 01/25/11 RPI 1139 C2X ARG IN QUOTES FOR NOALLOW
 * 2022-05-03 update copyright, add to z390\rt\mlc, fix SETC '&&' to '&'
 * 2022-05-07 replace TESTSUB1 with CVTTOHEX to remove dependency
+* 2024-07-24 #509 comment tests that now fail due to #509 changes
 *********************************************************************
          PRINT DATA
 TESTDC1  RT1   MAIN
@@ -439,14 +440,20 @@ CVTTOHEX2 RT1   CCE,=VD(CVTTOHEX),=AL8(CVTTOHEX) RPI 1044 DIFF ADDR
 &AVAL    SETA  2147483647
 &CHEX    SETC  A2X(&AVAL)
          RT1   CCE,=C'&CHEX',=C'7FFFFFFF'
+* Next test succeeds; will fail when 2147483648 flagged as error #509
          RT1   CCE,=A(2147483648),=X'80000000'      TEST SETA OVERFLOW
-&AVAL    SETA  2147483648
-&CHEX    SETC  A2X(&AVAL)                     TEST NEG A2X
-         RT1   CCE,=C'&CHEX',=C'80000000'
-         RT1   CCE,=A(2147483649),=X'80000001'      
-&AVAL    SETA  2147483649
-&CHEX    SETC  A2X(&AVAL)
-         RT1   CCE,=C'&CHEX',=C'80000001'
+* Before SETA; now fails, as it should                      #509
+*&AVAL    SETA  2147483648                                  #509
+* After SETA; did the SETA fail? Yes                        #509
+*&CHEX    SETC  A2X(&AVAL)                     TEST NEG A2X #509
+*         RT1   CCE,=C'&CHEX',=C'80000000'                  #509
+* Next test succeeds; will fail when 2147483649 flagged as error #509
+         RT1   CCE,=A(2147483649),=X'80000001'
+* Before SETA; now fails, as it should                      #509
+*&AVAL    SETA  2147483649                                  #509
+* After SETA; did it fail? Yes                              #509
+*&CHEX    SETC  A2X(&AVAL)                                  #509
+*         RT1   CCE,=C'&CHEX',=C'80000001'                  #509
 &AVAL    SETA  1/0
          RT1   CCE,=A(&AVAL),=A(0)              TEST SETA DIVIDE BY 0 
 &CVAL    SETC  '12345'                                       

--- a/rt/mlc/TESTDC1.MLC
+++ b/rt/mlc/TESTDC1.MLC
@@ -50,6 +50,7 @@
 * 01/25/11 RPI 1139 C2X ARG IN QUOTES FOR NOALLOW
 * 2022-05-03 update copyright, add to z390\tests, fix SETC '&&' to '&'
 * 2022-05-07 replace TESTSUB1 with CVTTOHEX to remove dependency
+* 2024-07-24 #509 comment tests that now fail due to #509 changes
 *********************************************************************
          PRINT DATA
 TESTDC1  RT1   MAIN
@@ -439,14 +440,20 @@ CVTTOHEX2 RT1   CCE,=VD(CVTTOHEX),=AL8(CVTTOHEX) RPI 1044 DIFF ADDR
 &AVAL    SETA  2147483647
 &CHEX    SETC  A2X(&AVAL)
          RT1   CCE,=C'&CHEX',=C'7FFFFFFF'
+* Next test succeeds; will fail when 2147483648 flagged as error #509
          RT1   CCE,=A(2147483648),=X'80000000'      TEST SETA OVERFLOW
-&AVAL    SETA  2147483648
-&CHEX    SETC  A2X(&AVAL)                     TEST NEG A2X
-         RT1   CCE,=C'&CHEX',=C'80000000'
-         RT1   CCE,=A(2147483649),=X'80000001'      
-&AVAL    SETA  2147483649
-&CHEX    SETC  A2X(&AVAL)
-         RT1   CCE,=C'&CHEX',=C'80000001'
+* Before SETA; now fails, as it should                      #509
+*&AVAL    SETA  2147483648                                  #509
+* After SETA; did the SETA fail? Yes                        #509
+*&CHEX    SETC  A2X(&AVAL)                     TEST NEG A2X #509
+*         RT1   CCE,=C'&CHEX',=C'80000000'                  #509
+* Next test succeeds; will fail when 2147483649 flagged as error #509
+         RT1   CCE,=A(2147483649),=X'80000001'
+* Before SETA; now fails, as it should                      #509
+*&AVAL    SETA  2147483649                                  #509
+* After SETA; did it fail? Yes                              #509
+*CHEX    SETC  A2X(&AVAL)                                   #509
+*        RT1   CCE,=C'&CHEX',=C'80000001'                   #509
 &AVAL    SETA  1/0
          RT1   CCE,=A(&AVAL),=A(0)              TEST SETA DIVIDE BY 0 
 &CVAL    SETC  '12345'                                       

--- a/rt/mlc/TOPR2.MLC
+++ b/rt/mlc/TOPR2.MLC
@@ -1,0 +1,1779 @@
+***********************************************************************
+* z390 - Mainframe assembler emulator and run-time engine
+* Copyright (C) 2021 z390 Assembler LLC
+*
+* This file is part of z390.
+*
+* z390 is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 2 of the License, or
+* (at your option) any later version.
+* z390 is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License 
+* along with this program; if not, see https://www.gnu.org/licenses.
+***********************************************************************
+* 2024-07-25 #509 New program
+***********************************************************************
+*
+*
+***********************************************************************
+* Both rt/mlc/TOPR2.MLC and rt/test/TESTOPR2.MLC test the HLASM
+* built-in functions.
+*
+* TOPR2 uses code to test HLASM built-in functions.
+* TESTOPR2, modelled on original rt/test/TESTOPR1.MLC, uses MNOTE,AIF.
+***********************************************************************
+*
+***********************************************************************
+* TESTOPR2 is modeled on the previous TESTOPR1 test program to test
+* the HLASM built-in functions. TESTOPR1 tests a built-in function
+* as follows:
+*     1. Invoke the built-in function
+*     2. Use MNOTE to display the result
+*     3. Check the result using AIF, branching to an error MNOTE
+*        if the generated value is not the expected value.
+* For example, the TESTOPR1 test for the X2C built-in function is
+*
+*     &X2C     SETC  (X2C('F1'))
+*              MNOTE 'X2C(''F1'')=&X2C'
+*              AIF   ('&X2C'(4,1) NE '1').X2ERR
+*              ...
+*     .X2ERR   MNOTE 12,'X2 OPERATOR ERROR'
+*              AGO   .EXIT
+*              ...
+*
+* Note that if a test fails, all remaining tests are skipped.
+*
+*----------------------------------------------------------------------
+*
+* TOPR2 performs tests using assembler code and DC statements to
+* invoke and verify results. In addition, the HLASM Language
+* Reference examples for each built-in function are added as
+* tests (there are a few exceptions). Where a code test
+* completely replaces the corresponding MNOTE.AIF test(s) done
+* in TESTOPR2, the original test(s) are left in place but
+* branched around via AGO.
+*
+* The first version of TOPR2 replaces the tests for the 
+* DCVAL and DEQUOTE built-in functions and adds tests for the
+* DOUBLE built-in function. The tests for each is done in a
+* separate subroutine. The tests write output to a file,
+* TOPR2.TXT, that produces output similar to the TESTOPR2
+* MNOTE,AIF output.
+*
+* If a test case fails, error messages are written and testing
+* continues.
+*
+* Sample output for the DCVAL test and a simulated error.
+*
+*   DCVAL    tests: Begin
+*                DCVAL('') = ""
+*                DCVAL('''') = "'"
+*   *** Fail *** DCVAL('&&') = "&"
+*                Error for test group DCVAL    test number   3
+*                Generated 016E504C
+*                Expected  026E504C00
+*                DCVAL('a''''b') = "a'b"
+*                DCVAL('a''''b&&c') = "a'b&c"
+*                DCVAL('&&&&''''') = "&&''"
+*                DCVAL('''&&1''') = "'&&1'"
+*   DCVAL    tests: num pass     6 num fail     1
+*
+* Tests 1-2 and 4-7 succeed. Test 3 fails.
+*
+* The error shown is artificial. It was forced by changing the
+* expected length, 1, to 2.
+* Note that three error messages follow the "*** Fail ***" line:
+*   1, A message showing the test group and the test number
+*      within the test group.
+*   2. The generated value (the result of the DCVAL invocation) is
+*      shown in printable hexadecimal, as is the expected value.
+*      See the comments for the DCVAL test subroutine, TDCVAL, for
+*      for a description of the displayed values. Briefly, each
+*      is of the form
+*          FL1'length-of-value',C'>value<'
+*      The ">" and "<" delimit the value; they are present in case
+*      the value is null, which avoids an assembly error for C''.
+*   3. The third test is converting two ampersands to one ampersand.
+*      The generated length is 1 and the generated value is
+*      X'50', which is the EBCDIC value of ampersand. Changing the
+*      expected length back to 1 results in all tests succeeding.
+*
+*----------------------------------------------------------------------
+*
+* Registers on entry:
+*     R15  emtry point
+*     R14  return address
+*     R13  usable save area
+*
+* Registers on exit:
+*     R0 -- R14  as at entry
+*     R15  return code
+*            0  all code tests passed
+*            8  at least one code test failed
+* Files:
+*     Input:  none
+*
+*     Output: DDNAME = REPORT  file to contain code tests and results
+*
+***********************************************************************
+*
+TOPR2    CSECT
+         STM   14,12,12(13)        Save caller's registers
+         LR    12,15               R12 = base register
+         USING TOPR2,12            Establish addressability
+         L     11,=A(COMSTOR)      Common storage
+         USING COMSTOR,11          Overly common storage
+         LA    14,SAS              Current save area (1st in SA set)
+         ST    14,8(,13)           Chain
+         ST    13,4(,14)                 save areas
+         LR    13,14               Current save area
+*
+         OPEN  (REPORT,OUTPUT)     Open report file
+*
+         BAS   14,WrtBegCT         Write begin code tests header
+*
+*        Perform tests done with code
+*
+         SR    0,0                 Initialize totals
+         ST    0,Tot#P             Number of tests that pass
+         ST    0,Tot#F             Number of tests that fail
+*
+         LM    3,5,TesTsH          R3 --> first test header entry
+*                                  R4  =  length of entry
+*                                  R5 --> last test header entry
+TLp1     DS    0H
+         L     1,0(,3)             R1 --> parameter list for test group
+         BAS   14,WrtBegHd         Write begin test header
+         L     15,4(,3)            R15 --> A(test code)
+         L     15,0(,15)           R15 --> test code
+         BASR  14,15               Perform tests for test group
+         C     15,MaxRC            New maximum return code?
+         BNH   TLp1A               No
+         ST    15,MaxRC            Save new maximum return code
+TLp1A    DS    0H
+*
+*        Accumulate num pass, num fail totals and write subtotals
+*
+         L     2,4(,1)             R2 --> word = num tests that pass 
+         L     0,Tot#P             Add
+         A     0,0(,2)                 subtotal
+         ST    0,Tot#P                          to total
+*
+         L     2,8(,1)             R2 --> word = num tests that fail 
+         L     0,Tot#F             Add
+         A     0,0(,2)                 subtotal
+         ST    0,Tot#F                          to total
+*
+         BAS   14,WrtSTot          Write subtotals
+*
+         PUT   REPORT,Spaces       Blank line
+*
+         BXLE  3,4,TLp1            Process all test headers
+*
+         BAS   14,WrtGTot          Write grand totals
+*
+         BAS   14,WrtEndCT         Write end code tests trailer
+*
+         CLOSE (REPORT)            Close report file
+*
+         L     15,MaxRC            Set return code
+         L     13,4(,13)           Caller's save area
+         RETURN (14,12),RC=(15)    Restore R14, R0-R12; return
+*
+         LTORG
+*
+*        Pre-chained save area set
+*
+SAS      DS    0D                  Save area set for program
+         DC    F'0'
+         DC    A(0,*-8+72)
+         DC    15F'0'
+*
+         DC    F'0'
+         DC    A(*-4-72,*-8+72)
+         DC    15F'0'
+*
+         DC    F'0'
+         DC    A(*-4-72,*-8+72)
+         DC    15F'0'
+*
+         DC    F'0'
+         DC    A(*-4-72,*-8+72)
+         DC    15F'0'
+*
+         DC    F'0'
+         DC    A(*-4-72,*-8+72)
+         DC    15F'0'
+*
+         DC    F'0'
+         DC    A(*-4-72,0)
+         DC    15F'0'
+*
+***********************************************************************
+*        SYM equate used for SYSATTRA, SYSATTRP tests
+*
+*        RETURN macro in main code used in operator type O tests
+***********************************************************************
+*
+SYM      EQU   1,2,C'3',C'PGMA',gr32
+*
+*SYM EQU   val,len attr val, type attr val, pgm type val, asm type val
+*
+*
+***********************************************************************
+*        Begin internal subroutines for main code
+***********************************************************************
+*
+***********************************************************************
+* WrtBegCT  Write begin code tests header
+*
+* Registers at entry
+*        R11 common area
+*        R12 base register of caller
+*        R13 chained save area
+*        R14 return address
+*
+* Registers at exit
+*        R0-R15 same as at entry
+***********************************************************************
+*
+WrtBegCT DS    0H
+         STM   14,12,12(13)        Save caller's registers
+         L     13,8(,13)           Next save area
+*
+         MVC   RptLn,Spaces        Initialize report line
+         LA    2,L'RLBegCT-1       Length code of begin header line
+         LA    14,RptLn            Destination
+         LA    15,RLBegCT          Source
+         EX    2,CpyVal            Copy to report line
+*
+         PUT   REPORT,RptLn        Write begin header
+         PUT   REPORT,Spaces       Write blank line
+*
+         L     13,4(,13)           Caller's save area
+         LM    14,12,12(13)        Restore caller's registers
+         BR    14                  Return to caller
+*
+***********************************************************************
+* WrtEndCT  Write end code tests trailer
+*
+* Registers at entry
+*        R11 common area
+*        R12 base register of caller
+*        R13 chained save area
+*        R14 return address
+*
+* Registers at exit
+*        R0-R15 same as at entry
+***********************************************************************
+*
+WrtEndCT DS    0H
+         STM   14,12,12(13)        Save caller's registers
+         L     13,8(,13)           Next save area
+*
+         MVC   RptLn,Spaces        Initialize report line
+         PUT   REPORT,RptLn        Write blank line
+*
+         LA    2,L'RLEndCT-1       Length code of end header line
+         LA    14,RptLn            Destination
+         LA    15,RLEndCT          Source
+         EX    2,CpyVal            Copy to report line
+*
+         PUT   REPORT,RptLn        Write end trailer
+*
+         L     13,4(,13)           Caller's save area
+         LM    14,12,12(13)        Restore caller's registers
+         BR    14                  Return to caller
+*
+***********************************************************************
+* WrtBegHd  Write test group begin header
+*
+* Registers at entry
+*        R1  --> test parameter list
+*                +0 --> test group literal; FL1'len-lit',C'literal'
+*                remainder not referenced
+*        R11 common area
+*        R12 base register of caller
+*        R13 chained save area
+*        R14 return address
+*
+* Registers at exit
+*        R0-R15 same as at entry
+***********************************************************************
+*
+WrtBegHd DS    0H
+         STM   14,12,12(13)        Save caller's registers
+         L     13,8(,13)           Next save area
+*
+         L     2,0(,1)             Address of test literal
+         SR    3,3                 Prepare to get length
+         IC    3,0(,2)             Length of literal
+         MVC   RLBegLit,Spaces     Initialize area for literal
+         LA    14,RLBegLit         Destination
+         LA    15,1(,2)            Source
+         BCTR  3,0                 Length code
+         EX    3,CpyVal            Copy literal to buffer
+*
+         MVC   RptLn,Spaces        Initialize report line
+         LA    2,L'RLBeg-1         Length code of begin header line
+         LA    14,RptLn            Destination
+         LA    15,RLBeg            Source
+         EX    2,CpyVal            Copy to report line
+*
+         PUT   REPORT,RptLn        Write begin header
+*
+         L     13,4(,13)           Caller's save area
+         LM    14,12,12(13)        Restore caller's registers
+         BR    14                  Return to caller
+*
+***********************************************************************
+* WrtSTot  Write number pass, number fail subtotals
+*
+* Registers at entry
+*        R1  --> test parameter list
+*                +0 --> test group literal; FL1'len-lit',C'literal'
+*                +4 --> word = number of tests that passed
+*                +8 --> word = number of tests that failed
+*        R11 common area
+*        R12 base register of main code
+*        R13 chained save area
+*        R14 return address
+*
+* Registers at exit
+*        R0-R15 same as at entry
+***********************************************************************
+*
+WrtSTot  DS    0H
+         STM   14,12,12(13)        Save caller's registers
+         L     13,8(,13)           Next save area
+*
+         L     2,0(,1)             Address of test literal
+         SR    3,3                 Prepare to get length
+         IC    3,0(,2)             Length of literal
+         MVC   RLTotLit,Spaces     Initialize area for literal
+         LA    14,RLTotLit         Destination
+         LA    15,1(,2)            Source
+         BCTR  3,0                 Length code
+         EX    3,CpyVal            Copy literal to work area
+*
+         LM    8,9,4(1)            R8 --> number pass subtotal
+*                                  R9 --> number fail subtotal
+         L     0,0(,8)             Number of passed tests
+         CVD   0,DW                Convert to decimal
+         MVC   EDWK1,Pat1          Copy edit pattern
+         ED    EDWK1,DW+5          Convert to printable
+         MVC   RLTot#P,EDWK1+1     Copy to work area
+         L     0,0(,9)             Number of failed tests
+         CVD   0,DW                Convert to decimal
+         MVC   EDWK1,Pat1          Copy edit pattern
+         ED    EDWK1,DW+5          Convert to printable
+         MVC   RLTot#F,EDWK1+1     Copy to work area
+*
+         MVC   RptLn,Spaces        Initialize report line
+         LA    2,L'RLTot-1         Length code of subtotals line
+         LA    14,RptLn            Destination
+         LA    15,RLTot            Source
+         EX    2,CpyVal            Copy to report line
+*
+         PUT   REPORT,RptLn        Write subtotals
+*
+         L     13,4(,13)           Caller's save area
+         LM    14,12,12(13)        Restore caller's registers
+         BR    14                  Return to caller
+*
+***********************************************************************
+* WrtGTot  Write number pass, number fail grand totals
+*
+* Registers at entry
+*        R11 common area
+*        R12 base register of caller
+*        R13 chained save area
+*        R14 return address
+*
+* Registers at exit
+*        R0-R15 same as at entry
+***********************************************************************
+*
+WrtGTot  DS    0H
+         STM   14,12,12(13)        Save caller's registers
+         L     13,8(,13)           Next save area
+*
+         MVC   RLTotLit,Spaces     Initialize area for literal
+         MVC   RLTotLit(L'TotLit),TotLit   Copy literal
+*
+         L     0,Tot#P             Number of passed tests
+         CVD   0,DW                Convert to decimal
+         MVC   EDWK1,Pat1          Copy edit pattern
+         ED    EDWK1,DW+5          Convert to printable
+         MVC   RLTot#P,EDWK1+1     Copy to work area
+         L     0,Tot#F             Number of failed tests
+         CVD   0,DW                Convert to decimal
+         MVC   EDWK1,Pat1          Copy edit pattern
+         ED    EDWK1,DW+5          Convert to printable
+         MVC   RLTot#F,EDWK1+1     Copy to work area
+*
+         MVC   RptLn,Spaces        Initialize report line
+         LA    2,L'RLTot-1         Length code of totals line
+         LA    14,RptLn            Destination
+         LA    15,RLTot            Source
+         EX    2,CpyVal            Copy to report line
+*
+         PUT   REPORT,RptLn        Write grand totals
+*
+         L     13,4(,13)           Caller's save area
+         LM    14,12,12(13)        Restore caller's registers
+         BR    14                  Return to caller
+*
+***********************************************************************
+*        End internal subroutines for main code
+***********************************************************************
+*
+         LTORG ,
+*
+         DROP  12                  End main code 
+*
+***********************************************************************
+*        Begin internal subroutines for tests done with code
+***********************************************************************
+*
+*
+***********************************************************************
+* Chk1CV: Do one check for character valued built-in function
+*
+* Registers at entry
+*        R15  =  entry point
+*        R14  =  return address
+*        R13 --> chained save area
+*        R1  --> parameter block; DSECT CCVPB
+*
+* Registers at exit
+*        R0-R15 same as at entry
+***********************************************************************
+*
+Chk1CV   DS    0H
+         PUSH  USING
+         STM   14,12,12(13)        Save caller's registers
+         L     13,8(,13)           Next save area
+         LR    12,15               R12 = base register
+         USING Chk1CV,12           Establish addressability
+         L     11,=A(COMSTOR)      Common storage
+         USING COMSTOR,11          Overlay common storage
+*
+         LR    10,1                R10 --> parameter block
+         USING CCVPB,10            Overlay parameter block        
+*
+         LM    8,9,CCV#PF@         R8 --> word = number passed tests
+*                                  R9 --? word = number failed tests
+*
+         L     14,CCVT#@           S(word = last test number)
+         L     15,0(,14)           Increment
+         AHI   15,1                          test
+         ST    15,0(,14)                          count
+         LR    1,10                R1 --> parameter block
+         L     15,=A(ChkChVal)     Check one pair
+         BASR  14,15
+         LTR   5,15                Values equal? (save rc)
+         BZ    Chk1CV10            Yes; test passed
+         ST    15,CCVRC            No; save return code
+         L     14,0(,9)            Increment 
+         AHI   14,1                          number
+         ST    14,0(,9)                             failed
+         B     Chk1CV20            Show status
+Chk1CV10 DS    0H
+         L     14,0(,8)            Increment 
+         AHI   14,1                          number
+         ST    14,0(,8)                             passed
+Chk1CV20 DS    0H
+         LR    1,10                    A(parameter block)
+         L     15,=A(BldCVF)           Build "f('arg') = 'gval'"
+         BASR  14,15
+         MVC   RptLn,Spaces            Initialize report line
+         L     2,CCVBLOA@              A(Length of built output)
+         L     2,0(,2)                 Length of built output
+         BCTR  2,0                     Length code
+         LA    14,RptLn+L'ErrMsg1+1    Destination
+         L     15,CCVOA                Source
+         EX    2,CpyVal                Copy built output to report line
+         LTR   5,5                     Did check fail?
+         BZ    Chk1CV30                No; skip error message
+         MVC   RptLn(L'ErrMsg1),ErrMsg1    Copy error message
+Chk1CV30 DS    0H
+         PUT   REPORT,RptLn            Write the built data
+         LTR   5,5                     Error occurred?
+         BZ    Chk1CV40                No
+         LR    1,10                    Parameter block
+         L     15,=A(WrtChVal)         Write values with error message
+         BASR  14,15
+Chk1CV40 DS    0H
+         L     13,4(,13)           Caller's save area
+         LM    14,12,12(13)        Restore all registers
+         BR    14                  Return to caller
+*
+         LTORG  ,
+*
+         POP   USING
+*
+***********************************************************************
+* ChkChVal  Check charVal generated result versus actual result
+*
+* Results of the form
+*     FL1'len-value',C'>value<'
+* Value is delimited by ">" and "<"; value may be null
+*
+* Examples: FL1'1',C'>''<'    value is single apostrophe
+*           FL1'0',C'><'      value is null (empty string)
+*
+* Registers on entry
+*     R15  entry point
+*     R14  return address
+*     R13  usable save area on chain
+*     R1   parameter block; DSECT CCVPB
+*
+* Registers at exit
+*     R0-R14  as at entry
+*     R15     return code
+*             0  generated value same as actual value
+*             8  generated value differs from actual value
+***********************************************************************
+*
+ChkChVal DS    0H
+         PUSH  USING
+         STM   14,12,12(13)        Save caller's registers
+         L     13,8(,13)           Next save area
+         LR    12,15               R12 = base register
+         USING ChkChVal,12         Establish addressability
+*
+         SR    10,10               Initialize return code
+*
+         USING CCVPB,1             Overlay parameter block
+         L     2,CCVLIT@           R2 --> address of test literal
+         L     3,CCVT#@            R3 --> word = test number
+         LM    4,5,CCVGE@          R4 --> generated value
+*                                  R5 --> expected value
+*
+         CLC   0(1,4),0(5)         Lengths the same?
+         BNE   CCVRC8              No; then values are different
+         CLI   0(4),0              Lengths are zero?
+         BE    CCVExit             Yes; then values are equal
+         SR    6,6                 Prepare to get length
+         IC    6,0(,4)             Length of both values
+         BCTR  6,0                 Length code
+         EX    6,CCVComp           Compare values
+         BZ    CCVExit             Equal; done
+*NSI     B     CCVRC8              Not equal
+CCVRC8   DS    0H
+         LA    10,8                Values not equal
+*NSI     B     CCVExit             All done
+CCVExit  DS    0H
+         LR    15,10               Get return code
+         L     13,4(,13)           Caller's save area
+         L     14,12(,13)          Restore caller's registers
+         LM    0,12,20(13)         ... except R15
+         BR    14                  Return to caller
+*
+CCVComp  CLC   2(*-*,4),2(5)       Compare the values
+*
+         LTORG ,
+*
+         POP   USING
+*
+***********************************************************************
+* WrtChVal  Write printable hexadecimal values for charVal
+*           generated result and expected result
+*
+* Results of the form
+*     FL1'len-value',C'>value<'
+* Character value is delimited by ">" and "<"; value may be null
+*
+* Examples: FL1'1',C'>''<'    value is single apostrophe
+*           FL1'0',C'><'      value is null (empty string)
+*
+* The printable hexadecimal for the first example above is
+*           016E7D4C
+*              > ' < 
+*
+* Registers on entry
+*     R15  entry point
+*     R14  return address
+*     R13  usable save area on chain
+*     R1   parameter block; DSECT CCVPB
+*
+* Registers at exit
+*     R0-R15  as at entry
+***********************************************************************
+*
+WrtChVal DS    0H
+         PUSH  USING
+         STM   14,12,12(13)        Save caller's registers
+         L     13,8(,13)           Next save area
+         LR    12,15               R12 = base register
+         USING WrtChVal,12         Establish addressability
+         L     11,=A(COMSTOR)      Common storage
+         USING COMSTOR,11          Overlay storage         
+*
+         USING CCVPB,1             Overlay parameter block
+         L     3,CCVLIT@           R3 --> address of test literal
+         L     6,CCVT#@            R6 --> word = test number
+         LM    4,5,CCVGE@          R4 --> generated value
+*                                  R5 --> expected value
+         DROP  1                   End parameter block overlay
+*
+         L     6,0(,6)             Test number
+*
+         SR    1,1                 Prepare to get length
+         IC    1,0(,3)             Length of test group literal
+         CHI   1,L'WCV1TG          Too big?
+         BNH   WCV100              No; use value
+         LA    1,L'WCV1TG          Yes; set to max value
+WCV100   DS    0H
+*
+*        Write test group and test number
+*
+         BCTR  1,0                 Convert to length code
+         MVC   WCV1TG,Spaces       Initialize output area
+         
+         LA    14,WCV1TG           Destination
+         LA    15,1(,3)            Source
+         EX    1,CpyVal            Copy literal to buffer
+*
+         CVD   6,DW                Convert test number to packed dec
+         MVC   WCVEDWk,WCVPAT1     Copy edit pattern
+         ED    WCVEDWk,DW+6        Convert to printable
+         MVC   WCV1T#,WCVEDWk+1    Copy to buffer
+         MVC   RptLn,Spaces        Initialize report line
+         MVC   RptLn+L'ErrMsg1+1(L'WCVRL1),WCVRL1 Copy to report line
+         PUT   REPORT,RptLn        Write error message 1
+*
+*        Write generated value in printable hex
+*
+         MVC   WCV2L,WCV2LG        Copy literal to buffer
+         MVC   WCV2V,Spaces        Initialize output area
+*        
+         MVC   WCVX2PWK,Spaces     Initialize work area
+         SR    1,1                 Prepare to get length
+         IC    1,0(4)              Length of generated value
+         AHI   1,1+2               Account for FL1, >, <
+         BCTR  1,0                 Length code
+         LA    14,WCVX2PWK         Destination
+         LR    15,4                Source
+         EX    1,CpyVal            Copy to work
+         AHI   1,1                 Back to length
+         LA    15,WCVX2PWK         Source
+         LA    14,WCV2V            Destination
+WCVGLp   DS    0H
+         CHI   1,4                 At least 4 bytes?
+         BL    WCVGELp             No; done
+         UNPK  DW(9),0(5,15)       Convert 4 bytes
+         TR    DW,H2P              ... to printable hex
+         MVC   0(8,14),DW          Copy to buffer
+         AHI   1,-4                Decrement length
+         AHI   15,4                Next 4 source bytes
+         AHI   14,8                Next destination area
+         B     WCVGLp              Do all bytes
+WCVGELp  DS    0H
+         LTR   1,1                 1-3 bytes left?
+         BNP   WCVGPRT             No; write message
+         UNPK  DW(9),0(5,15)       Convert 4 bytes
+         TR    DW,H2P              ... to printable hex
+         AR    1,1                 Double number of bytes
+         BCTR  1,0                 Length code
+         LA    15,DW               Final source
+         EX    1,CpyVal            Copy to buffer
+         LA    14,1(1,14)          Past end
+WCVGPRT  DS    0H
+         LR    2,14                Past end of data
+         LA    15,WCVRL2           Begin of buffer
+         SR    2,15                Length of buffer used
+         BCTR  2,0                 Length code
+         MVC   RptLn,Spaces        Initialize report line
+         LA    14,RptLn+L'ErrMsg1+1    Destination
+         EX    2,CpyVal                Copy data to report line
+         PUT   REPORT,RptLn            Show hex generated value
+*
+*        Display expected value in printable hex
+*
+         MVC   WCV2L,WCV2LE        Copy literal to buffer
+         MVC   WCV2V,Spaces        Initialize output area
+*
+         MVC   WCVX2PWK,Spaces     Initialize work area
+         SR    1,1                 Prepare to get length
+         IC    1,0(5)              Length of expected value
+         AHI   1,1+2               Account for FL1, >, <
+         BCTR  1,0                 Length code
+         LA    14,WCVX2PWK         Destination
+         LR    15,5                Source
+         EX    1,CpyVal            Copy to work
+         AHI   1,1                 Back to length
+         LA    15,WCVX2PWK         Source
+         LA    14,WCV2V            Destination
+WCVELp   DS    0H
+         CHI   1,4                 At least 4 bytes?
+         BL    WCVEELp             No; done
+         UNPK  DW(9),0(5,15)       Convert 4 bytes
+         TR    DW,H2P              ... to printable hex
+         MVC   0(8,14),DW          Copy to buffer
+         AHI   1,-4                Decrement length
+         AHI   15,4                Next 4 source bytes
+         AHI   14,8                Next destination area
+         B     WCVELp              Do all bytes
+WCVEELp  DS    0H
+         LTR   1,1                 1-3 bytes left?
+         BNP   WCVEWRT             No; write the report line
+         UNPK  DW(9),0(5,15)       Convert 4 bytes
+         TR    DW,H2P              ... to printable hex
+         AR    1,1                 Double number of bytes
+         BCTR  1,0                 Length code
+         LA    15,DW               Final source
+         EX    1,CpyVal            Copy to buffer
+         LA    14,1(1,14)          Past end
+WCVEWRT  DS    0H
+         LR    2,14                Past end of data
+         LA    15,WCVRL2           Begin of buffer
+         SR    2,15                Length of buffer used
+         BCTR  2,0                 Length code
+         MVC   RptLn,Spaces        Initialize report line
+         LA    14,RptLn+L'ErrMsg1+1    Destination
+         EX    2,CpyVal                Copy data to report line
+         PUT   REPORT,RptLn            Show hex expected value
+*
+*        Exit
+*
+         L     13,4(,13)           Caller's save area
+         LM    14,12,12(13)        Restore caller's registers
+         BR    14                  Return to caller
+*
+WCVDW    DS    D,XL1               Doubleword work and pad
+WCVFW    DS    F,XL1               Fullword work and pad
+WCVPat1  DC    X'40202120'         Edit pattern 3 digits
+WCVEDWk  DS    CL4                 Edit work area
+*
+WCVRL1A  DS    0C
+         DC    C'Error for test group'
+         DC    C' '
+WCV1TG   DS    CL8
+         DC    C' '
+         DC    C'test number'
+         DC    C' '
+WCV1T#   DS    CL3
+WCVRL1B  DS    0C
+WCVRL1   EQU   WCVRL1A,WCVRL1B-WCVRL1A,C'C'
+*
+WCVRL2A  DS    0C
+WCV2L    DS    CL9
+         DC    C' '
+WCV2V    DS    CL80
+WCVRL2B  DS    0C
+WCVRL2   EQU   WCVRL2A,WCVRL2B-WCVRL2A,C'C'
+*
+WCV2LG   DC    CL(L'WCV2L)'Generated'
+WCV2LE   DC    CL(L'WCV2L)'Expected'
+*
+WCVX2PWK DS    CL40
+*
+         LTORG ,
+*
+         POP   USING
+*
+***********************************************************************
+* BldCVF  Build charVal function invocation string
+*
+* Results of the form
+*     FL1'len-value',C'>value<'
+* Value is delimited by ">" and "<"; value may be null
+*
+* Examples: FL1'1',C'>''<'    value is single apostrophe
+*           FL1'0',C'><'      value is null (empty string)
+*
+* Registers on entry
+*     R15  entry point
+*     R14  return address
+*     R13  usable save area on chain
+*     R11  address of common storage
+*     R1   parameter list
+*            +0 --> address of test group litersl
+*            +4 --> word = test number
+*            +8 --> generated value
+*           +12 --> expected value
+*           +16 --> argument value
+*           +20 --> word = length of output area; max = 256
+*           +24 --> output area for printable function and value
+*           +28 --> word to contain length of built output
+*
+* Registers at exit
+*     R0-R15  as at entry
+***********************************************************************
+*
+BldCVF   DS    0H
+         PUSH  USING
+         STM   14,12,12(13)        Save caller's registers
+         L     13,8(,13)           Next save area
+         LR    12,15               R12 = base register
+         USING BldCVF,12           Establish addressability
+         L     11,=a(COMSTOR)      Common storage
+         USING COMSTOR,11          Overlay Common storage         
+*
+         USING CCVPB,1             Overlay parameter block
+*
+         LM    6,10,0(1)           R6  =  address of test group literal
+*                                  R7  --> word = test number
+*                                  R8  --> generated value
+*                                  R9  --> actual value
+*                                  R10 --> function argument value
+         LR    3,6                 Test group literal
+         LR    4,8                 Generated value
+         LR    5,9                 Expected value
+         L     6,0(,7)             Test number
+*
+*        Initialize output area
+*
+         L     2,CCVLOA@           R2 --> word = length of output area
+         L     2,0(,2)             R2 = length of output area
+         CHI   2,L'Spaces          More than max length?
+         BNH   BCVF100             No; length okay
+         LHI   2,L'Spaces          Yes; set maximum length
+BCVF100  DS    0H
+         L     7,CCVOA             R7 --> output area
+         BCTR  2,0                 Length code
+         LR    14,7                Destination
+         LA    15,Spaces           Source
+         EX    2,CpyVal            Initialize output area to spaces
+*
+*        Build report line
+*          1. Function name
+*          2. "('"
+*          3. argument value
+*          4. "')"
+*          5. " = ""
+*          6  generated value
+*          7. """
+*
+*        1. Function name
+*
+         SR    2,2                 Prepare to get length
+         IC    2,0(,3)             Len test grp lit (function name)
+         BCTR  2,0                 Convert to length code
+         LR    14,7                Destination
+         LA    15,1(,3)            Source
+         EX    2,CpyVal            Copy function name to output area
+         LA    7,1(2,7)            Next position
+*
+*        2. "('"
+*
+         MVC   0(L'BCVFOP,7),BCVFOP    Copy open paren and single quote
+         LA    7,L'BCVFOP(,7)          Next position
+*
+*        3. Function argument
+*
+         SR    2,2                 Prepare to get length
+         IC    2,0(,10)            Len function argument value
+         LTR   2,2                 Len might be zero
+         BZ    BCVF200             Skip copy if null argument value
+         BCTR  2,0                 Convert to length code
+         LR    14,7                Destination
+         LA    15,2(,10)           Source (skip over len, '>'
+         EX    2,CpyVal            Copy function name to report line
+         LA    7,1(2,7)            Next position
+BCVF200  DS    0H
+*
+*        4. "')"
+*
+         MVC   0(L'BCVFCP,7),BCVFCP    Copy single quote & close paren
+         LA    7,L'BCVFCP(,7)          Next position
+*
+*        5. " = ""
+*
+         MVC   0(L'BCVFEQ,7),BCVFEQ    Copy equal sign and double quote
+         LA    7,L'BCVFEQ(,7)          Next position
+*
+*        6. Generated function value
+*
+         SR    2,2                 Prepare to get length
+         IC    2,0(,8)             Len generated value
+         LTR   2,2                 Len might be zero
+         BZ    BCVF300             Skip copy if null argument value
+         BCTR  2,0                 Convert to length code
+         LR    14,7                Destination
+         LA    15,2(,4)            Source
+         EX    2,CpyVal            Copy function name to output area
+         LA    7,1(2,7)            Next position
+BCVF300  DS    0H
+*
+*        7. """
+*
+         MVI   0(7),C'"'           Closing double quote
+         LA    7,1(,7)             Next position
+*
+         L     15,CCVBLOA@         A(word for built length)
+         S     7,CCVOA             Built length
+         ST    7,0(,15)            Return built length
+*
+         DROP  1                   Done with parameter list
+*
+*        Exit
+*
+         L     13,4(,13)           Caller's save area
+         LM    14,12,12(13)        Restore caller's registers
+         BR    14                  Return to caller
+*
+BCVFOP   DC    C'('''              Open paren and single quote
+BCVFCP   DC    C''')'              Single quote and close paren
+BCVFEQ   DC    C' = "'             Equal sign, double quote
+*
+         LTORG ,
+*
+         POP   USING
+*
+*
+***********************************************************************
+*        End   internal subroutines for tests done with code
+***********************************************************************
+*
+*
+***********************************************************************
+*        Common storage
+***********************************************************************
+*
+COMSTOR  DS    0D
+         DC    CL8'COMSTOR'        Eyecatcher
+*
+*        Tables for tests that are done using code
+*
+         DS    0D
+*
+*        Header for test headers
+*
+TestsH   DC    A(T01H,8,TNH,0)     1st, len 1, last, unused
+*
+T01H     DS    0D
+         DC    A(T01P,T01@)        Parm list, address of test code
+         DC    A(T02P,T02@)
+         DC    A(T03P,T03@)
+***********************************************************************
+*        Put new entries above this line
+***********************************************************************
+TNH      EQU   *-8
+*
+*        DCVAL tests
+*
+T01P     DS    0D                  Parameter list for test
+         DC    A(T01L)             Test Literal
+         DC    A(T01#P)            Number of tests that pass
+         DC    A(T01#F)            Number of tests that fail
+*
+T01L     DC    AL1(L'T01LV)        Test literal
+T01LV    DC    C'DCVAL'
+T01#P    DC    F'0'                Number of tests that pass
+T01#F    DC    F'0'                Number of tests that fail
+*
+T01@     DC    A(TDCVAL)           Address of test code
+*
+*        DEQUOTE tests
+*
+T02P     DS    0D                  Parameter list for test
+         DC    A(T02L)             Test Literal
+         DC    A(T02#P)            Number of tests that pass
+         DC    A(T02#F)            Number of tests that fail
+*
+T02L     DC    AL1(L'T02LV)
+T02LV    DC    C'DEQUOTE'
+T02#P    DC    F'0'                Number of tests that pass
+T02#F    DC    F'0'                Number of tests that fail
+*
+T02@     DC    A(TDEQUOTE)
+*
+*        DOUBLE tests
+*
+T03P     DS    0D                  Parameter list for test
+         DC    A(T03L)             Test Literal
+         DC    A(T03#P)            Number of tests that pass
+         DC    A(T03#F)            Number of tests that fail
+*
+T03L     DC    AL1(L'T03LV)
+T03LV    DC    C'DOUBLE'
+T03#P    DC    F'0'                Number of tests that pass
+T03#F    DC    F'0'                Number of tests that fail
+*
+T03@     DC    A(TDOUBLE)  
+*
+***********************************************************************
+*        End test data
+***********************************************************************
+*
+Tot#P    DC    F'0'                Total number of tests that pass
+Tot#F    DC    F'0'                Total number of tests that fail
+*
+MaxRC    DC    F'0'                Maximum return code
+*
+Spaces   DC    CL(RptLnLen)' '     Line of spaces
+*
+DW       DS    D,XL1               Doubleword work and pad
+Pat1     DC    X'402020202120'     Edit pattern
+EDWK1    DS    CL(L'Pat1)          Edit work area
+*
+*        Error messages
+*
+ErrMsg1  DC    C'*** Fail ***'     Error message; test failed
+*
+*        Report DCB and records
+*
+RptLnLen EQU   120                 Length of report line
+*
+REPORT   DCB   DDNAME=REPORT,DSORG=PS,RECFM=FT,LRECL=120,MACRF=PM
+*
+RptLn    DS    CL(RptLnLen)        Report line
+*
+TotLit   DC    C'Totals'           Literal for totals
+*
+RLBegCTA DS    0C
+         DC    C'*************** '
+         DC    C'Begin TOPR2 code tests '
+         DC    C'***************'
+RLBegCTB DS    0C
+RLBegCT  EQU   RLBegCTA,RLBegCTB-RLBegCTA,C'C'
+*
+RLEndCTA DS    0C
+         DC    C'*************** '
+         DC    C'End   TOPR2 code tests '
+         DC    C'***************'
+RLEndCTB DS    0C
+RLEndCT  EQU   RLEndCTA,RLEndCTB-RLEndCTA,C'C'
+*
+RLBegA   DS    0C
+RLBegLit DS    CL8
+         DC    CL1' '
+         DC    C'tests: '
+         DC    C'Begin'
+RLBegB   DS    0C
+RLBeg    EQU   RLBegA,RLBegB-RLBegA,C'C'
+*
+RLTotA   DS    0C
+RLTotLit DS    CL8
+         DC    CL1' '
+         DC    C'tests: '
+         DC    C'number pass '
+
+RLTot#P  DS    CL5
+         DC    CL2' '
+         DC    C'number fail '
+RLTot#F  DS    CL5
+RLTotB   DS    0C
+RLTot    EQU   RLTotA,RLTotB-RLTotA,C'C'
+*
+*        Executed instructions
+*
+CpyVal   MVC   0(*-*,14),0(15)     Copy value
+*
+***********************************************************************
+*        HLASM LR uses bold n to represent X'00', bold f for X'FF'
+***********************************************************************
+*
+T00FF2nf DC    256AL1(*-T00FF2nf)  Translate X'00' to n, X'FF' to f
+         ORG   T00FF2nf+0
+         DC    C'n'
+         ORG   T00FF2nf+X'FF'
+         DC    C'f'
+         ORG   ,
+*
+H2P      EQU   *-240               Hex to printable hex
+         DC    C'0123456789ABCDEF'
+         DS    0D                  End on doubleword
+COMSTORL EQU   *-COMSTOR           Length of common storage area
+*
+*
+***********************************************************************
+*        End of main code and storage.
+***********************************************************************
+*
+*
+***********************************************************************
+***********************************************************************
+*        Begin code tests
+***********************************************************************
+***********************************************************************
+*
+*
+***********************************************************************
+*        Begin DCVAL tests
+***********************************************************************
+*
+*
+***********************************************************************
+*        The DCVAL tests use ampersands and apostrophes. The original
+*        z390 test source rt/test/TESTOPR1.MLC uses MNOTE and AIF
+*        to show and verify DCVAL results. The test
+*            &DCVSTR  SETC  '''''&&&&1'''''
+*            &DCVAL   SETC  (DCVAL('&DCVSTR'))
+*                     MNOTE 'DCVAL(&DCVSTR)=&DCVAL'
+*                     AIF   ('&DCVAL' NE '''&&1''').DCVERR  RPI 1080
+*        when run using HLASM generates
+*            ** ASMA163W Operand not properly enclosed in quotes
+*        when processing the MNOTE while z390 does not generate
+*        an error.
+*
+*        The new tests use DC statements of the form
+*              &C       SETC  DCVAL('testString')
+*              &DC      SETC  DOUBLE('&C')
+*              &K       SETA  K'&C
+*                       DC    FL1'&K',C'>&DC<'
+*        The &K value is the actual length of the DCVAL result.
+*        The &DC value is the DCVAL result with doubled
+*        ampersands and apostrophes, making the value
+*        suitable for using in the generated DC statement
+*        shown above. (The enclosing ">", "<" avoid an assembly
+*        error when  &C is the null (empty) string.)
+*
+*        Code validates that the generated value is the expected
+*        value, which appears in a separate similar DC statement.
+*        For example,
+*            &NDX     SETA  &NDX+1           current test
+*                     B     DCVX&NDX         branch to code
+*            &C       SETC  DCVAL('''')      should be one apostrophe
+*            &DC      SETC  DOUBLE('&C')     double the value
+*            &K       SETA  K'&C             should be 1
+*            DCVA&NDX DC    FL1'2',C'>''''<' function argument value
+*            DCVG&NDX DC    FL1'&K',C'>&DC<' generated value
+*            DCVE&NDX DC    FL'1',C'>''<'    expected value
+*            *                               X'016E7D4C'
+*            *                                   --==--
+*            *                                    > ' <
+*            DCVX&NDX DS    0H
+*                     LA    1,DCVG&NDX       generated value 
+*                     LA    2,DCVE&NDX       expected value
+*                     LA    3,DCVA&NDX       function argument value
+*                     STM   1,3,CCVGEF@      put in parameter block
+*                     LR    1,10             parameter block
+*                     L     15,=A(Chk1CV)    generated : actual
+*                     BASR  14,15            perform test
+*
+*        The original DCVAL tests that use the MNOTE and AIF
+*        tests are left in TESTOPR2 but branched around via AGO.
+**********************************************************************
+*
+*
+***********************************************************************
+* TDCVAL  Test DCVAL
+*
+* Registers at entry:
+*        R15     entry point
+*        R14     return address
+*        R13     current chained save area
+*        R1  --> literal for test group; FL1'len-lit',C'lit'
+*        R1  --> parameter list
+*                +0 --> literal for test group; FL1'len-lit',C'lit'
+*                +4 --> word for number of tests that pass
+*                +8 --> word for number of tests that fail
+*        R11 --> common storage
+*
+* Registers at exit:
+*        R0--R14  as at entry
+*        R15      return code
+*                 0  all tests passed
+*                 8  at least one test failed
+***********************************************************************
+TDCVAL   DS    0H
+         PUSH  USING
+         STM   14,12,12(13)        Save caller's registers
+         L     13,8(,13)           Next save area on chain
+         LR    12,15               R12 = base register
+         USING TDCVAL,12           Establish addressability         
+         L     11,=A(COMSTOR)      Common storage area
+         USING COMSTOR,11          Overlay common storage
+*
+         XC    DCVPB,DCVPB         Initialize parameter block storage
+         LA    10,DCVPB            R10 --> parameter block
+         USING CCVPB,10            Overlay parameter block
+*
+         L     0,0(,1)             A(literal for test)
+*
+         ST    0,CCVLIT@           Put in parameter block
+         LA    2,DCVT#             Word = test number
+         ST    2,CCVT#@            Put in parameter block
+         LA    2,DCVLOA            Word = length of output area
+         ST    2,CCVLOA@           Put in parameter block
+         LA    2,DCVOA             Output area
+         ST    2,CCVOA             Put in parameter block
+         LA    2,DCVBLOA           Word to contain built output length
+         ST    2,CCVBLOA@          Put in parameter block
+*
+         LM    8,9,4(1)            R8 --> word = subtotal num pass
+*                                  R9 --> word = subtotal num fail
+         STM   8,9,CCV#PF@         Put in parameter block
+*
+         SR    15,15               Initialize values to zero
+         ST    15,0(,8)            Number tests passed
+         ST    15,0(,9)            Number tests failed
+         ST    15,DCVT#            Current test number
+*
+&NDX     SETA  0                   Test case
+*
+&AMP     SETC  '&&'(1,1)           LR p341; one ampersand
+*
+*----------------------------------------------------------------------
+*        HLASM LR examples
+*
+&NDX     SETA  &NDX+1              Current test
+         B     DCVX&NDX            Branch around test
+*
+*        SETC  DCVAL('')           value is "" (null string)
+&C       SETC  DCVAL('')
+&DC      SETC  DOUBLE('&C')
+&K       SETA  K'&C
+DCVA&NDX DC    FL1'0',C'><'        Function argument value
+DCVG&NDX DC    FL1'&K',C'>&DC<'    Generated value
+DCVE&NDX DC    FL1'0',C'><'        Expected value
+DCVX&NDX DS    0H
+         LA    1,DCVG&NDX          A(generated value)
+         LA    2,DCVE&NDX          A(expected value)
+         LA    3,DCVA&NDX          A(function argument value)
+         STM   1,3,CCVGEF@         Put in parameter block
+         LR    1,10                R1 --> parameter block
+         L     15,=A(Chk1CV)       Test routine
+         BASR  14,15               Perform test
+*
+&NDX     SETA  &NDX+1              Current test
+         B     DCVX&NDX            Branch around test
+*
+*        SETC  DCVAL('''')         value is "'" (single apostrophe)
+&C       SETC  DCVAL('''')
+&DC      SETC  DOUBLE('&C')
+&K       SETA  K'&C
+DCVA&NDX DC    FL1'2',C'>''''<'    Argument value
+DCVG&NDX DC    FL1'&K',C'>&DC<'    Generated value
+DCVE&NDX DC    FL1'1',C'>''''<'    Expected value
+DCVX&NDX DS    0H
+         LA    1,DCVG&NDX
+         LA    2,DCVE&NDX
+         LA    3,DCVA&NDX
+         STM   1,3,CCVGEF@         Put in parameter block
+         LR    1,10                R1 --> parameter block
+         L     15,=A(Chk1CV)       Test routine
+         BASR  14,15               Perform test
+*
+&NDX     SETA  &NDX+1              Current test
+         B     DCVX&NDX            Branch around test
+*
+*        SETC  DCVAL('&&')         value is "&" (single ampersand)
+&C       SETC  DCVAL('&&')
+&DC      SETC  DOUBLE('&C')
+&K       SETA  K'&C
+DCVA&NDX DC    FL1'2',C'>&&&&<'    Argument value
+DCVG&NDX DC    FL1'&K',C'>&DC<'    Generated value
+DCVE&NDX DC    FL1'1',C'>&&<'      Expected value
+DCVX&NDX DS    0H
+         LA    1,DCVG&NDX
+         LA    2,DCVE&NDX
+         LA    3,DCVA&NDX
+         STM   1,3,CCVGEF@         Put in parameter block
+         LR    1,10                R1 --> parameter block
+         L     15,=A(Chk1CV)       Test routine
+         BASR  14,15               Perform test
+*
+&NDX     SETA  &NDX+1              Current test
+         B     DCVX&NDX            Branch around test
+*
+*        SETC  DCVAL('a''''b')     value is "a'b"
+&C       SETC  DCVAL('a''''b')
+&DC      SETC  DOUBLE('&C')
+&K       SETA  K'&C
+DCVA&NDX DC    FL1'6',C'>a''''''''b<'
+DCVG&NDX DC    FL1'&K',C'>&DC<'
+DCVE&NDX DC    FL1'3',C'>a''b<'
+DCVX&NDX DS    0H
+         LA    1,DCVG&NDX
+         LA    2,DCVE&NDX
+         LA    3,DCVA&NDX
+         STM   1,3,CCVGEF@         Put in parameter block
+         LR    1,10                R1 --> parameter block
+         L     15,=A(Chk1CV)       Test routine
+         BASR  14,15               Perform test
+*
+&NDX     SETA  &NDX+1              Current test
+         B     DCVX&NDX            Branch around test
+*
+*        SETC  DCVAL('a''''b&&c')  value is "a'b&c"
+&C       SETC  DCVAL('a''''b&&c')
+&DC      SETC  DOUBLE('&C')
+&K       SETA  K'&C
+DCVA&NDX DC    FL1'9',C'>a''''''''b&&&&c<'
+DCVG&NDX DC    FL1'&K',C'>&DC<'
+DCVE&NDX DC    FL1'5',C'>a''b&&c<'
+DCVX&NDX DS    0H
+         LA    1,DCVG&NDX
+         LA    2,DCVE&NDX
+         LA    3,DCVA&NDX
+         STM   1,3,CCVGEF@         Put in parameter block
+         LR    1,10                R1 --> parameter block
+         L     15,=A(Chk1CV)       Test routine
+         BASR  14,15               Perform test
+*
+*        Preset &C  to "&&&&''''" (4 ampersands and 4 apostrophes)
+&C       SETC  '&AMP'.'&AMP'.'&AMP'.'&AMP'.'''''''''' (4 & 4 ')
+*
+*&DC      SETC  DOUBLE('&C')
+*&K       SETA  K'&C
+*         DC    FL1'&K',C'>&DC<'
+*
+&NDX     SETA  &NDX+1              Current test
+         B     DCVX&NDX            Branch around test
+*
+*        SETC  DCVAL('&C')         value is "&&''" (2 of each)
+&X       SETC  DCVAL('&C')
+&DX      SETC  DOUBLE('&X')
+&K       SETA  K'&X
+DCVA&NDX DC    FL1'8',C'>&&&&&&&&''''''''<'
+DCVG&NDX DC    FL1'&K',C'>&DX<'
+DCVE&NDX DC    FL1'4',C'>&&&&''''<'
+DCVX&NDX DS    0H
+         LA    1,DCVG&NDX
+         LA    2,DCVE&NDX
+         LA    3,DCVA&NDX
+         STM   1,3,CCVGEF@         Put in parameter block
+         LR    1,10                R1 --> parameter block
+         L     15,=A(Chk1CV)       Test routine
+         BASR  14,15               Perform test
+*----------------------------------------------------------------------
+*        z390 tests
+*
+*        Preset &C to "''&&1''"    (4 ', 2 &, digit 1; len 7)
+&C       SETC  '''''&&&&1'''''     string "''&&1''" len 7
+*
+&NDX     SETA  &NDX+1              Current test
+         B     DCVX&NDX            Branch around test
+*
+*        SETC  DCVAL('&C')         value is "'&&1'" len 5
+&X       SETC  DCVAL('&C')
+&DX      SETC  DOUBLE('&X')
+&K       SETA  K'&X
+DCVA&NDX DC    FL1'7',C'>''''&&&&1''''<'
+DCVG&NDX DC    FL1'&K',C'>&DX<'
+DCVE&NDX DC    FL1'5',C'>''&&&&1''<'
+DCVX&NDX DS    0H
+         LA    1,DCVG&NDX
+         LA    2,DCVE&NDX
+         LA    3,DCVA&NDX
+         STM   1,3,CCVGEF@         Put in parameter block
+         LR    1,10                R1 --> parameter block
+         L     15,=A(Chk1CV)       Test routine
+         BASR  14,15               Perform test
+*
+DCVExit  DS    0H
+         L     15,CCVRC            Get return code from parm block
+         L     13,4(,13)           Caller's save area
+         L     14,12(,13)          Restore caller's registers
+         LM    0,12,20(13)         ... except R15
+         BR    14                  Return to caller
+*
+         LTORG ,
+*
+         DS    0D
+DCVPB    DS    XL(CCVPBLEN)        Parameter block storage
+*
+DCVT#    DC    F'0'                Test number
+DCVLOA   DC    A(L'DCVOA)          Length of output area
+DCVBLOA  DC    F'0'                Length of built output
+DCVOA    DS    CL80                Output area
+*
+         POP   USING
+*
+*
+***********************************************************************
+*        End   DCVAL tests
+***********************************************************************
+*
+*
+***********************************************************************
+*        Begin DEQUOTE tests
+***********************************************************************
+*
+*
+***********************************************************************
+*        The DEQUOTE tests use ampersands and apostrophes. The same
+*        reasons listed in the DCVAL tests apply here. Similar
+*        processing is done. Read the details in the TDCVAL section.
+*
+*        The original DEQUOTE tests in TESTOPR2 are left in but
+*        branched around via AGO.
+***********************************************************************
+*
+*
+***********************************************************************
+* TDEQUOTE  Test DEQUOTE
+*
+* Registers at entry:
+*        R15     entry point
+*        R14     return address
+*        R13     current chained save area
+*        R1  --> parameter list
+*                +0 --> literal for test group; FL1'len-;it',C'lit'
+*                +4 --> word for number of tests that pass
+*                +8 --> word for number of tests that fail
+*        R11 --> common storage
+*
+* Registers at exit:
+*        R0--R14  as at entry
+*        R15      return code
+*                 0  all tests passed
+*                 8  at least one test failed
+***********************************************************************
+*
+TDEQUOTE DS    0H
+         PUSH  USING
+         STM   14,12,12(13)        Save caller's registers
+         L     13,8(,13)           Next save area on chain
+         LR    12,15               R12 = base register
+         USING TDEQUOTE,12         Establish addressability         
+         L     11,=A(COMSTOR)      Common storage area
+         USING COMSTOR,11          Overlay common storage
+*
+         XC    DEQPB,DEQPB         Initialize parameter block storage
+         LA    10,DEQPB            R10 --> parameter block
+         USING CCVPB,10            Overlay parameter block
+*
+         L     0,0(,1)             A(literal for test)
+         ST    0,CCVLIT@           Put in parameter block
+         LA    2,DEQT#             Word = test number
+         ST    2,CCVT#@            Put in parameter block
+         LA    2,DEQLOA            Word = length of output area
+         ST    2,CCVLOA@           Put in parameter block
+         LA    2,DEQOA             Output area
+         ST    2,CCVOA             Put in parameter block
+         LA    2,DEQBLOA           Word to contain built output length
+         ST    2,CCVBLOA@          Put in parameter block
+*
+         LM    8,9,4(1)            R8 --> word = subtotal num pass
+*                                  R9 --> word = subtotal num fail
+         STM   8,9,CCV#PF@         Put in parameter block
+*
+         SR    15,15               Initialize values to zero
+         ST    15,0(,8)            Number tests passed
+         ST    15,0(,9)            Number tests failed
+         ST    15,DEQT#            Current test number
+*
+&NDX     SETA  0                   Test case
+*
+&AMP     SETC  '&&'(1,1)           LR p341; one ampersand
+*
+*----------------------------------------------------------------------
+*        HLASM LR examples
+*
+&NDX     SETA  &NDX+1              Current test
+         B     DEQX&NDX            Branch around test
+*
+*        SETC  DEQUOTE('charstring')   value is "charstring"
+&C       SETC  DEQUOTE('charstring') 
+&DC      SETC  DOUBLE('&C')
+&K       SETA  K'&C 
+DEQA&NDX DC    FL1'10',C'>charstring<' Argument value
+DEQG&NDX DC    FL1'&K',C'>&C< '        Generated value
+DEQE&NDX DC    FL1'10',C'>charstring<' Expected value
+DEQX&NDX DS    0H
+         LA    1,DEQG&NDX          A(generated value)
+         LA    2,DEQE&NDX          A(expected value)
+         LA    3,DEQA&NDX          A(argument value)
+         STM   1,3,CCVGEF@         Put in parameter block
+         LR    1,10                R1 --> parameter block
+         L     15,=A(Chk1CV)       Test routine
+         BASR  14,15               Perform test
+*
+&NDX     SETA  &NDX+1              Current test
+         B     DEQX&NDX            Branch around test
+*
+*        SETC  DEQUOTE('')         value is ""
+&C       SETC  DEQUOTE('') 
+&DC      SETC  DOUBLE('&C')
+&K       SETA  K'&C 
+DEQA&NDX DC    FL1'0',C'><'        Argument value
+DEQG&NDX DC    FL1'&K',C'>&C< '    Generated value
+DEQE&NDX DC    FL1'0',C'><'        Expected value
+DEQX&NDX DS    0H
+         LA    1,DEQG&NDX          A(generated value)
+         LA    2,DEQE&NDX          A(expected value)
+         LA    3,DEQA&NDX          A(argument value)
+         STM   1,3,CCVGEF@         Put in parameter block
+         LR    1,10                R1 --> parameter block
+         L     15,=A(Chk1CV)       Test routine
+         BASR  14,15               Perform test
+*
+&NDX     SETA  &NDX+1              Current test
+         B     DEQX&NDX            Branch around test
+*
+*        SETC  DEQUOTE('a')        value is "a"
+&C       SETC  DEQUOTE('a') 
+&DC      SETC  DOUBLE('&C')
+&K       SETA  K'&C
+DEQA&NDX DC    FL1'1',C'>a<'       Argument value
+DEQG&NDX DC    FL1'&K',C'>&C< '    Generated value
+DEQE&NDX DC    FL1'1',C'>a<'       Expected value
+DEQX&NDX DS    0H
+         LA    1,DEQG&NDX          A(generated value)
+         LA    2,DEQE&NDX          A(expected value)
+         LA    3,DEQA&NDX          A(argument value)
+         STM   1,3,CCVGEF@         Put in parameter block
+         LR    1,10                R1 --> parameter block
+         L     15,=A(Chk1CV)       Test routine
+         BASR  14,15               Perform test
+*
+&NDX     SETA  &NDX+1              Current test
+         B     DEQX&NDX            Branch around test
+*
+&ARG     SETC  '''a'''
+*&ARG    SETC  '''a'''             &ARG is "'a'"
+*        SETC  DEQUOTE('&ARG')     value is "a"
+&C       SETC  DEQUOTE('&ARG') 
+&DC      SETC  DOUBLE('&C')
+&K       SETA  K'&C
+DEQA&NDX DC    FL1'3',C'>''a''<'   Argument value
+DEQG&NDX DC    FL1'&K',C'>&C< '    Generated value
+DEQE&NDX DC    FL1'1',C'>a<'       Expected value
+DEQX&NDX DS    0H
+         LA    1,DEQG&NDX          A(generated value)
+         LA    2,DEQE&NDX          A(expected value)
+         LA    3,DEQA&NDX          A(argument value)
+         STM   1,3,CCVGEF@         Put in parameter block
+         LR    1,10                R1 --> parameter block
+         L     15,=A(Chk1CV)       Test routine
+         BASR  14,15               Perform test
+*
+&NDX     SETA  &NDX+1              Current test
+         B     DEQX&NDX            Branch around test
+*
+*        SETC  DEQUOTE('a''b')     value is "a'b"
+&C       SETC  DEQUOTE('a''b') 
+&DC      SETC  DOUBLE('&C')
+&K       SETA  K'&C
+DEQA&NDX DC    FL1'4',C'>a''''b<'  Argument value
+DEQG&NDX DC    FL1'&K',C'>&DC< '   Generated value
+DEQE&NDX DC    FL1'3',C'>a''b<'    Expected value
+DEQX&NDX DS    0H
+         LA    1,DEQG&NDX          A(generated value)
+         LA    2,DEQE&NDX          A(expected value)
+         LA    3,DEQA&NDX          A(argument value)
+         STM   1,3,CCVGEF@         Put in parameter block
+         LR    1,10                R1 --> parameter block
+         L     15,=A(Chk1CV)       Test routine
+         BASR  14,15               Perform test
+*
+&NDX     SETA  &NDX+1              Current test
+         B     DEQX&NDX            Branch around test
+*
+&ARG     SETC  ''''''
+*&ARG    SETC  ''''''              &ARG is "''"
+*        SETC  DEQUOTE('&ARG')     value is ""
+&C       SETC  DEQUOTE('&ARG') 
+&DC      SETC  DOUBLE('&C')
+&K       SETA  K'&C
+DEQA&NDX DC    FL1'2',C'>''''<'    Argument value
+DEQG&NDX DC    FL1'&K',C'>&C< '    Generated value
+DEQE&NDX DC    FL1'0',C'><'        Expected value
+DEQX&NDX DS    0H
+         LA    1,DEQG&NDX          A(generated value)
+         LA    2,DEQE&NDX          A(expected value)
+         LA    3,DEQA&NDX          A(argument value)
+         STM   1,3,CCVGEF@         Put in parameter block
+         LR    1,10                R1 --> parameter block
+         L     15,=A(Chk1CV)       Test routine
+         BASR  14,15               Perform test
+*
+*----------------------------------------------------------------------
+*        z390 tests
+*
+&NDX     SETA  &NDX+1              Current test
+         B     DEQX&NDX            Branch around test
+*
+&ARG     SETC  '''ABC'''
+*&ARG    SETC  '''ABC'''           &ARG is "'ABC'"
+*        SETC  DEQUOTE('&ARG')     value is "ABC"
+&C       SETC  DEQUOTE('&ARG') 
+&DC      SETC  DOUBLE('&C')
+&K       SETA  K'&C
+DEQA&NDX DC    FL1'5',C'>''ABC''<' Argument value
+DEQG&NDX DC    FL1'&K',C'>&C< '    Generated value
+DEQE&NDX DC    FL1'3',C'>ABC<'     Expected value
+DEQX&NDX DS    0H
+         LA    1,DEQG&NDX          A(generated value)
+         LA    2,DEQE&NDX          A(expected value)
+         LA    3,DEQA&NDX          A(argument value)
+         STM   1,3,CCVGEF@         Put in parameter block
+         LR    1,10                R1 --> parameter block
+         L     15,=A(Chk1CV)       Test routine
+         BASR  14,15               Perform test
+*
+DEQExit  DS    0H
+         L     15,CCVRC            Get return code from parameter block
+         L     13,4(,13)           Caller's save area
+         L     14,12(,13)          Restore caller's registers
+         LM    0,12,20(13)         ... except R15
+         BR    14                  Return to caller
+*
+         LTORG  ,
+*
+         DS    0D
+DEQPB    DS    XL(CCVPBLEN)        Parameter block storage
+*
+DEQT#    DC    F'0'                Test number
+DEQLOA   DC    A(L'DEQOA)          Length of output area
+DEQBLOA  DC    F'0'                Length of built output
+DEQOA    DS    CL80                Output area
+*
+         POP   USING
+*
+*
+***********************************************************************
+*        End   DEQUOTE tests
+***********************************************************************
+*
+*
+***********************************************************************
+*        Begin DOUBLE tests
+***********************************************************************
+*
+*
+***********************************************************************
+* TDOUBLE  Test DOUBLE
+*
+* Registers at entry:
+*        R15     entry point
+*        R14     return address
+*        R13     current chained save area
+*        R1  --> parameter list
+*                +0 --> literal for test group; FL1'len-;it',C'lit'
+*                +4 --> word for number of tests that pass
+*                +8 --> word for number of tests that fail
+*        R11 --> common storage
+*
+* Registers at exit:
+*        R0--R14  as at entry
+*        R15      return code
+*                 0  all tests passed
+*                 8  at least one test failed
+***********************************************************************
+*
+TDOUBLE  DS    0H
+         PUSH  USING
+         STM   14,12,12(13)        Save caller's registers
+         L     13,8(,13)           Next save area on chain
+         LR    12,15               R12 = base register
+         USING TDOUBLE,12          Establish addressability         
+         L     11,=A(COMSTOR)      Common storage area
+         USING COMSTOR,11          Overlay common storage
+*
+         XC    DOUPB,DOUPB         Initialize parameter block storage
+         LA    10,DOUPB            R10 --> parameter block
+         USING CCVPB,10            Overlay parameter block
+*
+         L     0,0(,1)             A(literal for test)
+*
+         ST    0,CCVLIT@           Put in parameter block
+         LA    2,DOUT#             Word = test number
+         ST    2,CCVT#@            Put in parameter block
+         LA    2,DOULOA            Word = length of output area
+         ST    2,CCVLOA@           Put in parameter block
+         LA    2,DOUOA             Output area
+         ST    2,CCVOA             Put in parameter block
+         LA    2,DOUBLOA           Word to contain built output length
+         ST    2,CCVBLOA@          Put in parameter block
+*
+         LM    8,9,4(1)            R8 --> word = subtotal num pass
+*                                  R9 --> word = subtotal num fail
+         STM   8,9,CCV#PF@         Put in parameter block
+*
+         SR    15,15               Initialize values to zero
+         ST    15,0(,8)            Number tests passed
+         ST    15,0(,9)            Number tests failed
+         ST    15,DOUT#            Current test number
+*
+&NDX     SETA  0                   Test case
+*
+&AMP     SETC  '&&'(1,1)           LR p341; one ampersand
+*
+*----------------------------------------------------------------------
+*        HLASM LR examples
+*
+&NDX     SETA  &NDX+1              Current test
+         B     DOUX&NDX            Branch around test
+* 
+*        Preset &C 
+&C       SETC  '&AMP'.'&AMP'.''''''.'&AMP' LR p331 "&&''&"; (2 ', 3 &) 
+* 
+*        &C contains "&&''&" (2 apostrophes, 3 ampersands) 
+*        SETC  DOUBLE('&C') 
+&DC      SETC  DOUBLE('&C')
+&DDC     SETC  DOUBLE('&DC')  
+&K       SETA  K'&DC
+DOUA&NDX DC    FL1'5',C'>&&&&''''&&<'
+DOUG&NDX DC    FL1'&K',C'>&DDC<'
+DOUE&NDX DC    FL1'10',C'>&&&&&&&&''''''''&&&&<'
+DOUX&NDX DS    0H
+         LA    1,DOUG&NDX          A(generated value)
+         LA    2,DOUE&NDX          A(expected value)
+         LA    3,DOUA&NDX          A(argument value)
+         STM   1,3,CCVGEF@         Put in parameter block
+         LR    1,10                R1 --> parameter block
+         L     15,=A(Chk1CV)       Test routine
+         BASR  14,15               Perform test
+*
+*----------------------------------------------------------------------
+*        z390 tests
+*
+*        No z390 tests
+*
+DOUExit  DS    0H
+         L     15,CCVRC            Get return code from parameter block
+         L     13,4(,13)           Caller's save area
+         L     14,12(,13)          Restore caller's registers
+         LM    0,12,20(13)         ... except R15
+         BR    14                  Return to caller
+*
+         LTORG  ,
+*
+         DS    0D
+DOUPB    DS    XL(CCVPBLEN)        Parameter block storage
+*
+DOUT#    DC    F'0'                Test number
+DOULOA   DC    A(L'DOUOA)          Length of output area
+DOUBLOA  DC    F'0'                Length of built output
+DOUOA    DS    CL80                Output area
+*
+         POP   USING
+*
+*
+***********************************************************************
+*        End   DOUBLE tests
+***********************************************************************
+*
+*
+***********************************************************************
+***********************************************************************
+*        End   code tests
+***********************************************************************
+***********************************************************************
+*
+         TITLE 'DSECTs'
+***********************************************************************
+*       Parameter block for ChkChVal and subroutines
+***********************************************************************
+*
+CCVPB    DSECT
+CCVLIT@  DS    A                   Test group literal
+CCVT#@   DS    A                   A(word = test number)
+CCVGEF@  DS    0AL12               A(gen,expected,argument values)
+CCVGE@   DS    0AL8                A(generated,expected values)
+CCVGV    DS    A                   A(generated value)
+CCVEV    DS    A                   A(expected value)
+CCVFAV   DS    A                   A(function argument value)
+CCVLOA@  DS    A                   A(word = length output area)
+CCVOA    DS    A                   A(output area)
+CCVBLOA@ DS    A                   A(word = built output length)
+CCVRC    DS    F                   Return code from failed test(s);
+*                                  Zero if all tests passed
+CCV#PF@  DS    0AL8                A(num pass, num fail tests)
+CCV#P@   DS    A                   A(word = number of passed tests)
+CCV#F@   DS    A                   A(word = number of failed tests)
+CCVPBLEN EQU   *-CCVPB             Length of parameter block
+*
+         END

--- a/rt/test/TESTOPR2.MLC
+++ b/rt/test/TESTOPR2.MLC
@@ -184,7 +184,7 @@ SYM      EQU   1,2,C'3',C'PGMA',gr32
 &A2B     SETC  A2B(-7)
          MNOTE 'A2B(-7)=&A2B'
          AIF   ('&A2B' NE '11111111111111111111111111111001').A2ERR
-*        TODO Put next in error test; did generate errors
+*        Put next (error) test in separate test  #999
 *&A2B     SETC  A2B(2345678901)         error; too large
 *         MNOTE 'A2B(2345678901)=&A2B'
 ** ASMA037E Illegal self-defining value - 2345678901)
@@ -404,17 +404,7 @@ SYM      EQU   1,2,C'3',C'PGMA',gr32
 &C2B     SETC  C2B('')
          MNOTE 'C2B('''')=>&C2B<'
          AIF   (K'&C2B NE 0).C2ERR
-***********************************************************************
-*        TODO how to type the null character?
-*             Was able to do so on z/OS then download file.
-*             See /home/john/z390/tests/JJGOPR3.MLC.
-*             Text editor gedit complained about the 0x00 value.
-*             DO NOT ATTEMPT TO SAVE THE FILE ON A PC!!!
-*
-*             Running "bash/asm JJGOPR3 'chksrc(0)'" with next 3
-*             lines uncommented with null character in place of n
-*             yielded &C2B set to '00000000' as expected.
-***********************************************************************
+*        Put next (successful) test in separate test  #999
 *&C2B     SETC  C2B('n')               n = null char = X'00'
 *         MNOTE 'C2B(''n'')=&C2B'
 *         AIF   ('&C2B' NE '00000000').C2ERR
@@ -450,9 +440,7 @@ SYM      EQU   1,2,C'3',C'PGMA',gr32
 &C2D     SETC  C2D('')                 at most 4 characters
          MNOTE 'C2D('''')=&C2D'
          AIF   ('&C2D' NE '+0').C2ERR
-***********************************************************************
-*        TODO: See JJGOPR3.MLC for next test; it succeeded.
-***********************************************************************
+*        Put next (successful) test in separate test  #999
 *&C2D     SETC  C2D('nj')              n = null character = X'00'
 *         MNOTE 'C2D(''nj'')=&C2D'
 *         AIF   ('&C2D' NE '+145').C2ERR
@@ -481,9 +469,7 @@ SYM      EQU   1,2,C'3',C'PGMA',gr32
 &C2X     SETC  C2X('')
          MNOTE 'C2X('''')=>&C2X<'
          AIF   (K'&C2X NE 0).C2ERR
-***********************************************************************
-*        TODO: See JJGOPR3.MLC for next test; it succeeded.
-***********************************************************************
+*        Put next (successful) test in separate test  #999
 *&C2X     SETC  C2X('n')                 n = null character = X'00'
 *         MNOTE 'C2X(''n'')=&C2X'
 *         AIF   ('&C2X' NE '00').C2ERR
@@ -899,11 +885,7 @@ SYM      EQU   1,2,C'3',C'PGMA',gr32
 &ISBIN   SETA  ISBIN('12121')                         non-binary digits
          MNOTE 'ISBIN(''12121'')=&ISBIN' 
          AIF   (&ISBIN NE 0).ISERR
-***********************************************************************
-*        TODO: Next test now produces
-*                MNOTE 8,'ISBIN invalid operand value; length is zero'
-*              on z390, as it should. Need to add test to error tests
-* 
+*        Put next (error) test in separate test  #999
 *ISBIN   SETA  ISBIN('')                              error condition 
 *        MNOTE 'ISBIN('''')=&ISBIN' 
 *        AIF   (&ISBIN NE 0).ISERR 
@@ -941,11 +923,7 @@ SYM      EQU   1,2,C'3',C'PGMA',gr32
 &ISDEC   SETA  ISDEC('00000000005')            too many digits; max 10
          MNOTE 'ISDEC(''00000000005'')=&ISDEC' 
          AIF   (&ISDEC NE 0).ISERR 
-***********************************************************************
-*        TODO: Next test now produces
-*                MNOTE 8,'ISDEC invalid operand value; length is zero'
-*              on z390, as it should. Need to add test to error tests
-* 
+*        Put next (error) test in separate test  #999
 *&ISDEC   SETA  ISDEC('')                      error condition
 *         MNOTE 'ISDEC('''')=&ISDEC' 
 *         AIF   (&ISDEC NE 0).ISERR
@@ -980,11 +958,7 @@ SYM      EQU   1,2,C'3',C'PGMA',gr32
 &ISHEX   SETA  ISHEX('123456789')              too many chars; 8 max 
          MNOTE 'ISHEX(''123456789'')=&ISHEX' 
          AIF   (&ISHEX NE 0).ISERR
-***********************************************************************
-*        TODO: Next test now produces
-*                MNOTE 8,'ISHEX invalid operand value; length is zero'
-*              on z390, as it should. Need to add test to error tests
-* 
+*        Put next (error) test in separate test  #999
 *&ISHEX   SETA  ISHEX('')                      error condition
 *         MNOTE 'ISHEX('''')=&ISHEX' 
 *         AIF   (&ISHEX NE 0).ISERR
@@ -1022,11 +996,7 @@ SYM      EQU   1,2,C'3',C'PGMA',gr32
 &ISSYM   SETA  ISSYM('1234_Abcd')              invalid initial char
          MNOTE 'ISSYM(''1234_Abcd'')=&ISSYM' 
          AIF   (&ISSYM NE 0).ISERR
-***********************************************************************
-*        TODO: Next test now produces
-*                MNOTE 8,'ISSYM invalid operand value; length is zero'
-*              on z390, as it should. Need to add test to error tests
-* 
+*        Put next (error) test in separate test  #999
 *&ISSYM   SETA  ISSYM('')                      error condition
 *         MNOTE 'ISSYM('''')=&ISSYM' 
 *         AIF   (&ISSYM NE 0).ISERR
@@ -1136,10 +1106,7 @@ SYM      EQU   1,2,C'3',C'PGMA',gr32
 &SLA     SETA  (X'3FFFFFFF' SLA 1)
          MNOTE '(X''3FFFFFFF'' SLA 1) = &SLA'
          AIF   (&SLA NE X'7FFFFFFE').SLAERR
-***********************************************************************
-*         TODO: Next 2 tests result in arithmetic overflow
-*               Create error tests
-*
+*        Put next two (error) test in separate tests  #999
 *&SLA     SETA  (X'7FFFFFFF' SLA 1)            ASMA075E arith overflow
 *         MNOTE '(X''7FFFFFFF'' SLA 1) = &SLA'
 *         AIF   (&SLA NE X'7FFFFFFE').SLAERR

--- a/rt/test/TESTOPR2.MLC
+++ b/rt/test/TESTOPR2.MLC
@@ -1,0 +1,1443 @@
+***********************************************************************
+* z390 - Mainframe assembler emulator and run-time engine
+* Copyright (C) 2021 z390 Assembler LLC
+*
+* This file is part of z390.
+*
+* z390 is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; either version 2 of the License, or
+* (at your option) any later version.
+* z390 is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License 
+* along with this program; if not, see https://www.gnu.org/licenses.
+***********************************************************************
+* 2024-07-25 #509 New program
+***********************************************************************
+*
+*
+***********************************************************************
+* TESTOPR2 modelled on original rt/test/TESTOPR1.MLC
+***********************************************************************
+*
+*        Generate a box with border character and containing 'text'
+*
+*        MBOX 'Hello World',BORDER=$  gemerates
+*
+*        $$$$$$$$$$$$$$$$$$$$$$$
+*        $$$   Hello World   $$$
+*        $$$$$$$$$$$$$$$$$$$$$$$
+*
+         MACRO
+         MBOX &TEXT,&BORDER=*
+         LCLA &I,&N
+         LCLC &L,&R,&M,&S,&T
+         AIF   (K'&TEXT LT 3).EXIT     No box if no text
+&S       SETC  '*'                     Default border character
+         AIF   (K'&BORDER EQ 0).BOK
+&S       SETC  '&BORDER'(1,1)          Get supplied border character
+.BOK     ANOP
+&M       SETC  '&TEXT'(2,K'&TEXT-2)    Extract message from 'text'
+&L       SETC  '&S'.'&S'.'&S'.'   '  ' Left side and pad
+&R       SETC  '   '.'&S'.'&S'.'&S'    Pad and right side
+&I       SETA  1
+&N       SETA  K'&L+k'&M+K'&R          Width of box (height is 3)
+&T       SETC  ''
+.L1      ANOP                          Build top and bottom border
+         AIF   (&I GT &N).EL1
+&T       SETC  '&T'.'&S'
+&I       SETA  &I+1
+         AGO   .L1
+.EL1     ANOP
+.*       Display the box
+         MNOTE '&T'
+         MNOTE '&L.&M.&R'
+         MNOTE '&T'
+         AGO   .EXIT
+.EXIT    ANOP
+         MEND
+*
+*        Variables used by most of the tests
+*
+         LCLC  &AMP
+         LCLC  &C,&DC,&X,&DX
+         LCLA  &K
+         LCLA  &NDX
+*
+***********************************************************************
+* TESTOPR2 is modelled on the previous TESTOPR1 test program to test
+* the HLASM built-in functions. TESTOPR1 tests a built-in function
+* as follows:
+*     1. Invoke the built-in function
+*     2. Use MNOTE to display the result
+*     3. Check the result using AIF, branching to an error MNOTE
+*        if the generated value is not the expected value.
+* For example, the TESTOPR1 test for the X2C built-in function is
+*
+*     &X2C     SETC  (X2C('F1'))
+*              MNOTE 'X2C(''F1'')=&X2C'
+*              AIF   ('&X2C'(4,1) NE '1').X2ERR
+*              ...
+*     .X2ERR   MNOTE 12,'X2 OPERATOR ERROR'
+*              AGO   .EXIT
+*              ...
+*
+* Note that if a test fails, all remaining tests are skipped. In
+* addition, the assembly of TESTOPR2 fails, so neither the link
+* nor the execution is done.
+*
+*----------------------------------------------------------------------
+*
+* TESTOPR2 also uses this technique. However, some tests have been
+* moved to a new test program, rt/mlc/TOPR2.MLC, which does its
+* tests using assembler code and DC statements to invoke and
+* verify results. In addition, the HLASM Language Reference examples
+* for each built-in function are added as TESTOPR2 tests (there are
+* a few exceptions). Where code tests in TOPR2 completely replace
+* the corresponding MNOTE.AIF tests, the original tests are
+* left in but branched around via AGO.
+*
+*----------------------------------------------------------------------
+*
+* Registers on entry:
+*     R15  emtry point
+*     R14  return address
+*     R13  usable save area
+*
+* Registers on exit:
+*     R0 -- R14  as at entry
+*     R15  return code
+*            0  always
+*
+* Note: Since all tests are done via MNOTE and AIF, if a test fails
+*       then the assembly fails due to an error MNOTE. Therefore,
+*       if the assembly succeeds, all tests have succeeded.
+*
+***********************************************************************
+*
+TESTOPR2 CSECT
+         STM   14,12,12(13)        Save caller's registers
+         LR    12,15               R12 = base register
+         USING TESTOPR2,12         Establish addressability
+*
+         WTO   'TESTOPR2  Test HLASM built-in functions via MNOTE,AIF'
+*
+         SR    15,15               Set return code
+         RETURN (14,12),RC=(15)    Restore R14, R0-R12; return
+*
+         LTORG
+*
+***********************************************************************
+*        SYM equate used for SYSATTRA, SYSATTRP tests
+*
+*        RETURN macro in main code used in operator type O tests
+***********************************************************************
+*
+SYM      EQU   1,2,C'3',C'PGMA',gr32
+*
+*SYM EQU   val,len attr val, type attr val, pgm type val, asm type val
+*
+.LOOP    ANOP
+&PASS    SETA  &PASS+1
+         AIF   (&PASS GE 2).ENDLOOP
+         MNOTE 'TESTOPR1 Pass &PASS'
+***********************************************************************
+         MBOX  'Test UPPER and LOWER'
+*AGO .SKPUL
+&MC      SETC  'aBcDeFg'
+&LC      SETC  'abc'
+         AIF   ('&LC' NE 'abc').LCERR
+&LC      SETC  '&MC'
+         AIF   ('&LC' NE 'aBcDeFg').LCERR
+*&UC      SETC  (UPPER '&LC')
+&UC      SETC  (UPPER '&LC')
+         AIF   ('&UC' NE 'ABCDEFG').UCERR
+&UC      SETC  'ABC'
+         AIF   ('&UC' NE 'ABC').UCERR
+&UC      SETC  '&MC'
+         AIF   ('&UC' NE 'aBcDeFg').UCERR
+*&LC      SETC  (LOWER '&UC')
+&LC      SETC  (LOWER '&UC')
+         AIF   ('&LC' NE 'abcdefg').LCERR
+.SKPUL ANOP
+***********************************************************************
+         MBOX  'Test ?2? functions'
+*AGO .SKPX2Y
+*======================================================================
+         MNOTE '********** Begin A2B tests **********'
+*----------------------------------------------------------------------
+*        HLASM LR examples
+
+&A2B     SETC  A2B(0)
+         MNOTE 'A2B(0)=&A2B'
+         AIF   ('&A2B' NE '00000000000000000000000000000000').A2ERR
+&A2B     SETC  A2B(5)
+         MNOTE 'A2B(5)=&A2B'
+         AIF   ('&A2B' NE '00000000000000000000000000000101').A2ERR
+&A2B     SETC  A2B(1022)
+         MNOTE 'A2B(1022)=&A2B'
+         AIF   ('&A2B' NE '00000000000000000000001111111110').A2ERR
+&A2B     SETC  A2B(-7)
+         MNOTE 'A2B(-7)=&A2B'
+         AIF   ('&A2B' NE '11111111111111111111111111111001').A2ERR
+*        TODO Put next in error test; did generate errors
+*&A2B     SETC  A2B(2345678901)         error; too large
+*         MNOTE 'A2B(2345678901)=&A2B'
+** ASMA037E Illegal self-defining value - 2345678901)
+
+*----------------------------------------------------------------------
+*        z390 tests
+
+&A2B     SETC  A2B(4)
+         MNOTE 'A2B(4)=&A2B'
+         AIF   ('&A2B' NE '00000000000000000000000000000100').A2ERR
+&A2B     SETC  A2B(-4)
+         MNOTE 'A2B(-4)=&A2B'
+         AIF   ('&A2B' NE '11111111111111111111111111111100').A2ERR
+*----------------------------------------------------------------------
+         MNOTE '********** End   A2B tests **********'
+*======================================================================
+         MNOTE '********** Begin A2C tests **********'
+*----------------------------------------------------------------------
+*        HLASM LR examples
+
+&A2C     SETC  A2C(0)
+         MNOTE 'A2C(0)=>&A2C<'
+         AIF   (K'&A2C NE 4).A2ERR
+         DC    C'&A2C'             X'00000000'
+&A2C     SETC  A2C(241)
+         MNOTE 'A2C(241)=>&A2C<'
+         AIF   ('&A2C'(4,1) NE '1').A2ERR
+         DC    C'&A2C'             X'000000',C'1'
+&A2C     SETC  A2C(20046)
+         MNOTE 'A2C(20056)=>&A2C<'
+         AIF   ('&A2C'(3,2) NE '++').A2ERR
+         DC    C'&A2C'             X'0000',C'++'
+&A2C     SETC  A2C(-252645136)
+         MNOTE 'A2C(-252645136)=>&A2C<'
+         AIF   ('&A2C' NE '0000').A2ERR
+*----------------------------------------------------------------------
+         MNOTE '********** End   A2C tests **********'
+*======================================================================
+         MNOTE '********** Begin A2D tests **********'
+*----------------------------------------------------------------------
+*        HLASM LR examples
+
+&A2D     SETC  A2D(0)
+         MNOTE 'A2D(0)=>&A2D<'
+         AIF   ('&A2D' NE '+0').A2ERR
+&A2D     SETC  A2D(241)
+         MNOTE 'A2D(241)=>&A2D<'
+         AIF   ('&A2D' NE '+241').A2ERR
+&A2D     SETC  A2D(16448)
+         MNOTE 'A2D(16448)=>&A2D<'
+         AIF   ('&A2D' NE '+16448').A2ERR
+&A2D     SETC  A2D(-3)
+         MNOTE 'A2D(-3)=>&A2D<'
+         AIF   ('&A2D' NE '-3').A2ERR
+*----------------------------------------------------------------------
+*        z390 tests
+*
+&A2D     SETC  A2D(-241)
+         MNOTE 'A2D(-241)=>&A2D<'
+         AIF   ('&A2D' NE '-241').A2ERR
+*----------------------------------------------------------------------
+         MNOTE '********** End   A2D tests **********'
+*======================================================================
+         MNOTE '********** Begin A2X tests **********'
+*----------------------------------------------------------------------
+*        HLASM LR examples
+
+&A2X     SETC  A2X(0)
+         MNOTE 'A2X(0)=>&A2X<'
+         AIF   ('&A2X' NE '00000000').A2ERR
+&A2X     SETC  A2X(10)
+         MNOTE 'A2X(10)=>&A2X<'
+         AIF   ('&A2X' NE '0000000A').A2ERR
+&A2X     SETC  A2X(257)
+         MNOTE 'A2X(257)=>&A2X<'
+         AIF   ('&A2X' NE '00000101').A2ERR
+&A2X     SETC  A2X(1022)
+         MNOTE 'A2X(1022)=>&A2X<'
+         AIF   ('&A2X' NE '000003FE').A2ERR
+&A2X     SETC  A2X(-7)
+         MNOTE 'A2X(-7)=>&A2X<'
+         AIF   ('&A2X' NE 'FFFFFFF9').A2ERR
+*----------------------------------------------------------------------
+*        z390 tests
+
+&A2X     SETC  A2X(241)
+         MNOTE 'A2X(241)=>&A2X<'
+         AIF   ('&A2X' NE '000000F1').A2ERR
+&A2X     SETC  A2X(-241)
+         MNOTE 'A2X(-241)=>&A2X<'
+         AIF   ('&A2X' NE 'FFFFFF0F').A2ERR
+*----------------------------------------------------------------------
+         MNOTE '********** End   A2X tests **********'
+*======================================================================
+         MNOTE '********** Begin B2A tests **********'
+*----------------------------------------------------------------------
+*        HLASM LR examples
+
+&B2A     SETA  B2A('')
+         MNOTE 'B2A('''')=&B2A'
+         AIF   (&B2A NE 0).B2ERR
+&B2A     SETA  B2A('0000000101')
+         MNOTE 'B2A(''0000000101'')=&B2A'
+         AIF   (&B2A NE 5).B2ERR
+&B2A     SETA  B2A('11111111111111111111111111111110')
+&SB2A    SETC  SIGNED(&B2A)
+         MNOTE 'B2A(''11111111111111111111111111111110'')=&SB2A'
+         AIF   (&B2A NE -2).B2ERR
+         AIF   ('&SB2A' NE '-2').B2ERR
+*----------------------------------------------------------------------
+*        z390 tests
+
+&B2A     SETA  B2A('100')
+         MNOTE 'B2A(''100'')=&B2A'
+         AIF   (&B2A NE 4).B2ERR
+*----------------------------------------------------------------------
+         MNOTE '********** End   B2A tests **********'
+*======================================================================
+         MNOTE '********** Begin B2C tests **********'
+*----------------------------------------------------------------------
+*        HLASM LR examples
+
+&B2C     SETC  B2C('11110011')
+         MNOTE 'B2C(''11110011'')=&B2C'
+         AIF   ('&B2C' NE '3').B2ERR
+&B2C     SETC  B2C('101110011110001')
+         MNOTE 'B2C(''101110011110001'')=&B2C'
+         AIF   ('&B2C' NE '*1').B2ERR
+&B2C     SETC  B2C('0')                        EBCDIC null character
+         MNOTE 'B2C(''0'')=>&B2C<'
+         AIF   (K'&B2C NE 1).B2ERR
+         DC    C'&B2C'                         value X'00'
+&B2C     SETC  B2C('00010010001')
+         MNOTE 'B2C(''00010010001'')=&B2C'
+         AIF   (K'&B2C NE 2).B2ERR
+         AIF   ('&B2C'(2,1) NE 'j').B2ERR
+         DC    C'&B2C'                         value X'00',C'j'
+&B2C     SETC  B2C('000000000')                two EBCDIC nulls
+         MNOTE 'B2C(''000000000'')=&B2C'
+         AIF   (K'&B2C NE 2).B2ERR
+         DC    C'&B2C'                         value X'0000'
+&B2C     SETC  B2C('')                         null string
+         MNOTE 'B2C('''')=>&B2C<'              null string
+         AIF   (K'&B2C NE 0).B2ERR
+*----------------------------------------------------------------------
+         MNOTE '********** End   B2C tests **********'
+*======================================================================
+         MNOTE '********** Begin B2D tests **********'
+*----------------------------------------------------------------------
+*        HLASM LR examples
+
+&B2D     SETC  B2D('')
+         MNOTE 'B2D('''')=&B2D'
+         AIF   ('&B2D' NE '+0').B2ERR
+&B2D     SETC  B2D('00010010001')
+         MNOTE 'B2D(''00010010001'')=&B2D'
+         AIF   ('&B2D' NE '+145').B2ERR
+&B2D     SETC  B2D('11110001')
+         MNOTE 'B2D(''11110001'')=&B2D'
+         AIF   ('&B2D' NE '+241').B2ERR
+&B2D     SETC  B2D('01111111111111111111111111111111')
+         MNOTE 'B2D(''01111111111111111111111111111111'')=&B2D'
+         AIF   ('&B2D' NE '+2147483647').B2ERR
+&B2D     SETC  B2D('11111111111111111111111111110001')
+         MNOTE 'B2D(''11111111111111111111111111110001'')=&B2D'
+         AIF   ('&B2D' NE '-15').B2ERR
+*----------------------------------------------------------------------
+         MNOTE '********** End   B2D tests **********'
+*======================================================================
+         MNOTE '********** Begin B2X tests **********'
+*----------------------------------------------------------------------
+*        HLASM LR examples
+
+&B2X     SETC  B2X('')
+         MNOTE 'B2X('''')=>&B2X<'
+         AIF   (K'&B2X NE 0).B2ERR
+&B2X     SETC  B2X('00000')
+         MNOTE 'B2X(''00000'')=&B2X'
+         AIF   ('&B2X' NE '00').B2ERR
+&B2X     SETC  B2X('0000010010001')
+         MNOTE 'B2X(''0000010010001'')=&B2X'
+         AIF   ('&B2X' NE '0091').B2ERR
+&B2X     SETC  B2X('11110001')
+         MNOTE 'B2X(''11110001'')=&B2X'
+         AIF   ('&B2X' NE 'F1').B2ERR
+&B2X     SETC  B2X('1111110001')
+         MNOTE 'B2X(''1111110001'')=&B2X'
+         AIF   ('&B2X' NE '3F1').B2ERR
+*----------------------------------------------------------------------
+         MNOTE '********** End   B2X tests **********'
+*======================================================================
+         MNOTE '********** Begin C2A tests **********'
+*----------------------------------------------------------------------
+*        HLASM LR examples
+
+&C2A     SETA  C2A('')
+         MNOTE 'C2A('''')=&C2A'
+         AIF   (&C2A NE 0).C2ERR
+&C2A     SETA  C2A('+')
+         MNOTE 'C2A(''+'')=&C2A'
+         AIF   (&C2A NE 78).C2ERR
+&C2A     SETA  C2A('1')
+         MNOTE 'C2A(''1'')=&C2A'
+         AIF   (&C2A NE 241).C2ERR
+&C2A     SETA  C2A('0000')
+&SC2A    SETC  SIGNED(&C2A)
+         MNOTE 'C2A(''0000'')=&SC2A'
+         AIF   (&C2A NE -252645136).C2ERR
+         AIF   ('&SC2A' NE '-252645136').C2ERR
+*----------------------------------------------------------------------
+         MNOTE '********** End   C2A tests **********'
+*======================================================================
+         MNOTE '********** Begin C2B tests **********'
+*----------------------------------------------------------------------
+*        HLASM LR examples
+
+&C2B     SETC  C2B('')
+         MNOTE 'C2B('''')=>&C2B<'
+         AIF   (K'&C2B NE 0).C2ERR
+***********************************************************************
+*        TODO how to type the null character?
+*             Was able to do so on z/OS then download file.
+*             See /home/john/z390/tests/JJGOPR3.MLC.
+*             Text editor gedit complained about the 0x00 value.
+*             DO NOT ATTEMPT TO SAVE THE FILE ON A PC!!!
+*
+*             Running "bash/asm JJGOPR3 'chksrc(0)'" with next 3
+*             lines uncommented with null character in place of n
+*             yielded &C2B set to '00000000' as expected.
+***********************************************************************
+*&C2B     SETC  C2B('n')               n = null char = X'00'
+*         MNOTE 'C2B(''n'')=&C2B'
+*         AIF   ('&C2B' NE '00000000').C2ERR
+&C2B     SETC  C2B(' ')
+         MNOTE 'C2B('' '')=&C2B'
+         AIF   ('&C2B' NE '01000000').C2ERR
+&C2B     SETC  C2B('1')
+         MNOTE 'C2B(''1'')=&C2B'
+         AIF   ('&C2B' NE '11110001').C2ERR         
+&C2B     SETC  C2B('1234')
+         MNOTE 'C2B(''1234'')=&C2B'
+         AIF   ('&C2B' NE '11110001111100101111001111110100').C2ERR
+&C2B     SETC  C2B('A1')           Begin z390 tests
+         MNOTE 'C2B(''A1'')=&C2B'
+         AIF   ('&C2B' NE '1100000111110001').C2ERR
+&C2B     SETC  C2B('+')
+         MNOTE 'C2B(''+'')=&C2B'
+*        AIF   ('&C2B' NE '1100000111110001').C2ERR
+&C2B     SETC  C2B('&&')              error if only 1; returns 2
+         MNOTE 'C2B(''&&&&'')=&C2B' 
+         AIF   ('&C2B' NE '0101000001010000').C2ERR
+*z390         AIF   ('&C2B' NE '01010000').C2ERR  
+&C2B     SETC  C2B('''')              error if only 1; returns 1
+         MNOTE 'C2B('''''''')=&C2B' 
+         AIF   ('&C2B' NE '01111101').C2ERR
+*----------------------------------------------------------------------
+         MNOTE '********** End   C2B tests **********'
+*======================================================================
+         MNOTE '********** Begin C2D tests **********'
+*----------------------------------------------------------------------
+*        HLASM LR examples
+
+&C2D     SETC  C2D('')                 at most 4 characters
+         MNOTE 'C2D('''')=&C2D'
+         AIF   ('&C2D' NE '+0').C2ERR
+***********************************************************************
+*        TODO: See JJGOPR3.MLC for next test; it succeeded.
+***********************************************************************
+*&C2D     SETC  C2D('nj')              n = null character = X'00'
+*         MNOTE 'C2D(''nj'')=&C2D'
+*         AIF   ('&C2D' NE '+145').C2ERR
+&C2D     SETC  C2D('1')
+         MNOTE 'C2D(''1'')=&C2D'
+         AIF   ('&C2D' NE '+241').C2ERR
+&C2D     SETC  C2D('0000')
+         MNOTE 'C2D(''0000'')=&C2D'
+         AIF   ('&C2D' NE '-252645136').C2ERR
+*----------------------------------------------------------------------
+*        z390 tests
+
+&C2D     SETC  C2D('&&')              error if only 1; returns 2 
+         MNOTE 'C2D(''&&&&'')=&C2D' 
+         AIF   ('&C2D' NE '+20560').C2ERR 
+&C2D     SETC  C2D('''')              error if only 1; returns 1 
+         MNOTE 'C2D('''''''')=&C2D' 
+         AIF   ('&C2D' NE '+125').C2ERR
+*----------------------------------------------------------------------
+         MNOTE '********** End   C2D tests **********'
+*======================================================================
+         MNOTE '********** Begin C2X tests **********'
+*----------------------------------------------------------------------
+*        HLASM LR examples
+
+&C2X     SETC  C2X('')
+         MNOTE 'C2X('''')=>&C2X<'
+         AIF   (K'&C2X NE 0).C2ERR
+***********************************************************************
+*        TODO: See JJGOPR3.MLC for next test; it succeeded.
+***********************************************************************
+*&C2X     SETC  C2X('n')                 n = null character = X'00'
+*         MNOTE 'C2X(''n'')=&C2X'
+*         AIF   ('&C2X' NE '00').C2ERR
+&C2X     SETC  C2X('1')
+         MNOTE 'C2X(''1'')=&C2X'
+         AIF   ('&C2X' NE 'F1').C2ERR
+&C2X     SETC  C2X('a')
+         MNOTE 'C2X(''a'')=&C2X'
+         AIF   ('&C2X' NE '81').C2ERR
+&C2X     SETC  C2X('1234567R')
+         MNOTE 'C2X(''1234567R'')=&C2X'
+         AIF   ('&C2X' NE 'F1F2F3F4F5F6F7D9').C2ERR
+*----------------------------------------------------------------------
+         MNOTE '********** End   C2X tests **********'
+*======================================================================
+         MNOTE '********** Begin D2A tests **********'
+*----------------------------------------------------------------------
+*        HLASM LR examples
+
+&D2A     SETA  D2A('')                 returns 0
+         MNOTE 'D2A('''')=&D2A'
+         AIF   (&D2A NE 0).D2ERR
+&D2A     SETA  D2A('000')
+         MNOTE 'D2A(''000'')=&D2A'
+         AIF   (&D2A NE 0).D2ERR
+&D2A     SETA  D2A('10')
+         MNOTE 'D2A(''10'')=&D2A'
+         AIF   (&D2A NE 10).D2ERR
+&D2A     SETA  D2A('+100')
+         MNOTE 'D2A(''+100'')=&D2A'
+         AIF   (&D2A NE 100).D2ERR
+&D2A     SETA  D2A('-5')
+&SD2A    SETC  SIGNED(&D2A)
+         MNOTE 'D2A(''-5'')=&SD2A'
+         AIF   (&D2A NE -5).D2ERR
+         AIF   ('&SD2A' NE '-5').D2ERR
+*----------------------------------------------------------------------
+*        z390 tests
+
+&D2A     SETA  D2A('-10')
+&SD2A    SETC  SIGNED(&D2A)
+         MNOTE 'D2A(''-10'')=&SD2A'
+         AIF   (&D2A NE -10).D2ERR
+         AIF   ('&SD2A' NE '-10').D2ERR
+*----------------------------------------------------------------------
+         MNOTE '********** End   D2A tests **********'
+*======================================================================
+         MNOTE '********** Begin D2B tests **********'
+*----------------------------------------------------------------------
+*        HLASM LR examples
+
+&D2B     SETC  D2B('')
+         MNOTE 'D2B('''')=>&D2B<'
+         AIF   (K'&D2B NE 0).D2ERR
+&D2B     SETC  D2B('0')
+         MNOTE 'D2B(''0'')=&D2B'
+         AIF   ('&D2B' NE '00000000000000000000000000000000').D2ERR
+&D2B     SETC  D2B('+5')
+         MNOTE 'D2B(''5'')=&D2B'
+         AIF   ('&D2B' NE '00000000000000000000000000000101').D2ERR
+&D2B     SETC  D2B('1022')
+         MNOTE 'D2B(''1022'')=&D2B'
+         AIF   ('&D2B' NE '00000000000000000000001111111110').D2ERR
+&D2B     SETC  D2B('-7')
+         MNOTE 'D2B(''-7'')=&D2B'
+         AIF   ('&D2B' NE '11111111111111111111111111111001').D2ERR
+*----------------------------------------------------------------------
+         MNOTE '********** End   D2B tests **********'
+*======================================================================
+         MNOTE '********** Begin D2C tests **********'
+*----------------------------------------------------------------------
+*        HLASM LR examples
+
+*        For the first example, HLASM LR states "indicates an error".
+*        However, HLASM does not generate an error and returns
+*        an empty string.
+&D2C     SETC  D2C('')                 indicates an error; set to ''
+         MNOTE 'D2C('''')=>&D2C<'
+         AIF   (K'&D2C NE 0).D2ERR
+&D2C     SETC  D2C('0')                four EBCDIC null bytes
+         MNOTE 'D2C(''0'')=&D2C'
+         AIF   (K'&D2C NE 4).D2ERR
+         DC    C'&D2C'                 X'00000000'
+&D2C     SETC  D2C('+126')
+         MNOTE 'D2C(''+126'')=&D2C'
+         AIF   ('&D2C'(4,1) NE '=').D2ERR
+         DC    C'&D2C'                 X'000000',C'='
+&D2C     SETC  D2C('247')
+         MNOTE 'D2C(''247'')=&D2C'
+         AIF   ('&D2C'(4,1) NE '7').D2ERR
+         DC    C'&D2C'                 X'000000',C'7'
+&D2C     SETC  D2C('23793')
+         MNOTE 'D2C(''23793'')=&D2C'
+         AIF   ('&D2C'(3,2) NE '*1').D2ERR
+         DC    C'&D2C'                 X'0000',C'*1'
+&D2C     SETC  D2C('-7')
+         MNOTE 'D2C(''-7'')=&D2C'
+         AIF   ('&D2C'(4,1) NE '9').D2ERR
+         DC    C'&D2C'                 X'FFFFFF',C'9'
+*----------------------------------------------------------------------
+         MNOTE '********** End   D2C tests **********'
+*======================================================================
+         MNOTE '********** Begin D2X tests **********'
+*----------------------------------------------------------------------
+*        HLASM LR examples
+
+*        For the first example, HLASM LR states "indicates an error".
+*        However, HLASM does not generate an error and returns
+*        an empty string.
+&D2X     SETC  D2X('')                indicates an error; set to ''
+         MNOTE 'D2X('''')=>&D2X<'
+         AIF   (K'&D2X NE 0).D2ERR
+&D2X     SETC  D2X('0')
+         MNOTE 'D2X(''0'')=&D2X'
+         AIF   ('&D2X' NE '00000000').D2ERR
+&D2X     SETC  D2X('+5')
+         MNOTE 'D2X(''+5'')=&D2X'
+         AIF   ('&D2X' NE '00000005').D2ERR
+&D2X     SETC  D2X('255')
+         MNOTE 'D2X(''255'')=&D2X'
+         AIF   ('&D2X' NE '000000FF').D2ERR
+&D2X     SETC  D2X('01022')
+         MNOTE 'D2X(''01022'')=&D2X'
+         AIF   ('&D2X' NE '000003FE').D2ERR
+&D2X     SETC  D2X('-7')
+         MNOTE 'D2X(''-7'')=&D2X'
+         AIF   ('&D2X' NE 'FFFFFFF9').D2ERR
+*----------------------------------------------------------------------
+         MNOTE '********** End   D2X tests **********'
+*======================================================================
+         MNOTE '********** Begin X2A tests **********'
+*----------------------------------------------------------------------
+*        HLASM LR examples
+
+&X2A     SETA  X2A('00000101')
+         MNOTE 'X2A(''00000101'')=&X2A'
+         AIF   (&X2A NE 257).X2ERR
+&X2A     SETA  X2A('C1')
+         MNOTE 'X2A(''C1'')=&X2A'
+         AIF   (&X2A NE 193).X2ERR
+&X2A     SETA  X2A('')
+         MNOTE 'X2A('''')=&X2A'
+         AIF   (&X2A NE 0).X2ERR
+&X2A     SETA  X2A('FFFFFFF0')
+&SX2A    SETC  SIGNED(&X2A)
+         MNOTE 'X2A(''FFFFFFF0'')=&SX2A'
+         AIF   (&X2A NE -16).X2ERR
+         AIF   ('&SX2A' NE '-16').X2ERR
+*----------------------------------------------------------------------
+*        z390 tests
+
+&X2A     SETA  X2A('F1')
+         MNOTE 'X2A(''F1'')=&X2A'
+         AIF   (&X2A NE 241).X2ERR
+*----------------------------------------------------------------------
+         MNOTE '********** End   X2A tests **********'
+*======================================================================
+         MNOTE '********** Begin X2B tests **********'
+*----------------------------------------------------------------------
+*        HLASM LR examples
+
+&X2B     SETC  X2B('')
+         MNOTE 'X2B('''')=>&X2B<'
+         AIF   (K'&X2B NE 0).X2ERR
+&X2B     SETC  X2B('00')
+         MNOTE 'X2B(''00'')=&X2B'
+         AIF   ('&X2B' NE '00000000').X2ERR
+&X2B     SETC  X2B('1')
+         MNOTE 'X2B(''1'')=&X2B'
+         AIF   ('&X2B' NE '0001').X2ERR
+&X2B     SETC  X2B('F3')
+         MNOTE 'X2B(''F3'')=&X2B'
+         AIF   ('&X2B' NE '11110011').X2ERR
+&X2B     SETC  X2B('00F3')
+         MNOTE 'X2B(''00F3'')=&X2B'
+         AIF   ('&X2B' NE '0000000011110011').X2ERR
+*----------------------------------------------------------------------
+*        z390 tests
+
+&X2B     SETC  X2B('1F')
+         MNOTE 'X2B(''1F'')=&X2B'
+         AIF   ('&X2B' NE '00011111').X2ERR
+*----------------------------------------------------------------------
+         MNOTE '********** End   X2B tests **********'
+*======================================================================
+         MNOTE '********** Begin X2C tests **********'
+*----------------------------------------------------------------------
+*        HLASM LR examples
+
+&X2C     SETC  X2C('')
+         MNOTE 'X2C('''')=>&X2C<'
+         AIF   (K'&X2C NE 0).X2ERR
+         DC    C'>&X2C<'               C'><'
+&X2C     SETC  X2C('F3')
+         MNOTE 'X2C(''F3'')=&X2C'
+         AIF   ('&X2C' NE '3').X2ERR
+&X2C     SETC  X2C('0')
+         MNOTE 'X2C(''0'')=&X2C'
+         AIF   (K'&X2C NE 1).X2ERR
+         DC    C'&X2C'                 X'00'
+&X2C     SETC  X2C('F1F2F3F4F5')
+         MNOTE 'X2C(''F1F2F3F4F5'')=&X2C'
+         AIF   ('&X2C' NE '12345').X2ERR
+&X2C     SETC  X2C('000F1')
+         MNOTE 'X2C(''000F1'')=&X2C'
+         AIF   (K'&X2C NE 3).X2ERR
+         AIF   ('&X2C'(3,1) NE '1').X2ERR
+         DC    C'&X2C'                 X'0000',C'1'
+*----------------------------------------------------------------------
+*        z390 tests
+
+&X2C     SETC  X2C('F1')
+         MNOTE 'X2C(''F1'')=&X2C'
+         AIF   ('&X2C' NE '1').X2ERR
+*----------------------------------------------------------------------
+         MNOTE '********** End   X2C tests **********'
+*======================================================================
+         MNOTE '********** Begin X2D tests **********'
+*----------------------------------------------------------------------
+*        HLASM LR examples
+
+&X2D     SETC  X2D('')
+         MNOTE 'X2D('''')=&X2D'
+         AIF   ('&X2D' NE '+0').X2ERR
+&X2D     SETC  X2D('91')
+         MNOTE 'X2D(''91'')=&X2D'
+         AIF   ('&X2D' NE '+145').X2ERR
+&X2D     SETC  X2D('000F1')
+         MNOTE 'X2D(''000F1'')=&X2D'
+         AIF   ('&X2D' NE '+241').X2ERR
+&X2D     SETC  X2D('7FFFFFFF')
+         MNOTE 'X2D(''7FFFFFFF'')=&X2D'
+         AIF   ('&X2D' NE '+2147483647').X2ERR
+&X2D     SETC  X2D('FFFFFFF1')
+         MNOTE 'X2D(''FFFFFFF1'')=&X2D'
+         AIF   ('&X2D' NE '-15').X2ERR
+*----------------------------------------------------------------------
+*        z390 tests
+
+&X2D     SETC  X2D('F1')
+         MNOTE 'X2D(''F1'')=&X2D'
+         AIF   ('&X2D' NE '+241').X2ERR
+*----------------------------------------------------------------------
+         MNOTE '********** End   X2D tests **********'
+*======================================================================
+.SKPX2Y ANOP
+***********************************************************************
+*        MBOX  'Test DCLEN, DCVAL, DEQUOTE'
+         MBOX  'Test DCLEN'
+*AGO .SKPDC
+*======================================================================
+         MNOTE '********** Begin DCLEN tests **********'
+*----------------------------------------------------------------------
+*        HLASM LR examples
+
+&DCLEN   SETA  DCLEN('')                 null string
+         MNOTE 'DCLEN('''')=&DCLEN'
+         AIF   (&DCLEN NE 0).DCLERR
+&DCLEN   SETA  DCLEN('''')               single apostrophe
+         MNOTE 'DCLEN('''''''')=&DCLEN'
+         AIF   (&DCLEN NE 1).DCLERR
+&DCLEN   SETA  DCLEN('''''')             two apostrophes
+         MNOTE 'DCLEN('''''''''''')=&DCLEN'
+         AIF   (&DCLEN NE 1).DCLERR
+&DCLEN   SETA  DCLEN('&&')               two ampersands
+         MNOTE 'DCLEN(''&&&&'')=&DCLEN'
+         AIF   (&DCLEN NE 1).DCLERR
+&DCLEN   SETA  DCLEN('a''''b')           string is "a'b"
+         MNOTE 'DCLEN(''a''''''''b'')=&DCLEN'
+         AIF   (&DCLEN NE 3).DCLERR
+&DCLEN   SETA  DCLEN('a''''b&&c')        string is "a'b&c""
+         MNOTE 'DCLEN(''a''''''''b&&&&c'')=&DCLEN'
+         AIF   (&DCLEN NE 5).DCLERR
+&DCLEN   SETA  DCLEN('&&&&'.'''''''')    string is "&&''"
+         MNOTE 'DCLEN(''&&&&&&&&''.'''''''''''''''')=&DCLEN'
+         AIF   (&DCLEN NE 4).DCLERR
+*----------------------------------------------------------------------
+*        z390 tests
+
+&DCLSTR  SETC  '''''''''&&&&&&&&1'''''''''  len 17; see MNOTE below
+&K       SETA  K'&DCLSTR 
+&DDCLSTR SETC  DOUBLE('&DCLSTR')            double for MNOTE and DC
+*
+         MNOTE 'K''&&DCLSTR=&K  &&DCLSTR = >&DDCLSTR<'
+***********************************************************************
+*        On z390 the preceding MNOTE displays
+*
+*  MNOTE 'K'&DCLSTR=17  &DCLSTR = >''''''''&&&&&&&&&&&&&&&&1''''''''<'
+*
+*        Using HLASM the MNOTE displays
+*
+* +K'&DCLSTR=17  &DCLSTR = >''''&&&&&&&&1''''<           
+*
+*        Looks like mz390 just shows the MNOTE with the message
+*        text doubled, not the actual output of the MNOTE.
+*
+*        The following DC statement is the same for both z390 & HLASM.
+***********************************************************************
+         PUSH  PRINT
+         PRINT DATA
+         DC    FL1'&K',C'>&DDCLSTR<' 
+         POP   PRINT
+*
+&DCLEN   SETA  DCLEN('&DCLSTR') 
+         MNOTE 'DCLEN(''&&DCLSTR'')=&DCLEN' 
+         AIF   (&DCLEN NE 9).DCLERR
+*----------------------------------------------------------------------
+         MNOTE '********** End   DCLEN tests **********'
+*======================================================================
+         AGO   .SKPDCVO    DCVAL tests now done in rt/mlc/TOPR2.MLC
+         MNOTE '********** Begin DCVAL tests **********'
+*----------------------------------------------------------------------
+*        HLASM LR examples
+*
+******** old DCVAL tests
+&DCVAL   SETC  DCVAL('')                 null string
+&K       SETA  K'&DCVAL
+         MNOTE 'DCVAL('''')=>&DCVAL<  length = &K'
+         AIF   (K'&DCVAL NE 0).DCVERR
+*
+&DCVAL   SETC  DCVAL('''')               one apostrophe
+&K       SETA  K'&DCVAL
+         MNOTE 'DCVAL('''''''')=>&DCVAL&DCVAL<  length = &K'
+&K       SETA  K'&DCVAL
+         MNOTE 'K''&&DCVAL = &K'
+         AIF   ('&DCVAL' NE '''').DCVERR
+*
+&DCVAL   SETC  DCVAL('&&')               one ampersand
+&K       SETA  K'&DCVAL
+&DCVAL2  SETC  '&DCVAL'.'&DCVAL'
+         MNOTE 'DCVAL(''&&&&'')=>&DCVAL2<'
+         AIF   ('&DCVAL2' NE '&&').DCVERR
+*
+&DCVAL   SETC  DCVAL('a''''b')           string is "a'b"
+&K       SETA  K'&DCVAL
+*        MNOTE 'DCVAL(''a''''''''b'')=>&DCVAL<  length = &K'
+         AIF   ('&DCVAL' NE 'a''b').DCVERR
+* AGO .JJG3
+*
+&DCVAL   SETC  DCVAL('a''''b&&c')        string is "a'b&c"
+&K       SETA  K'&DCVAL
+&W1      SETC  DOUBLE('a''''b&&c')
+&W2      SETC  DOUBLE('&DCVAL')
+&K       SETA  K'&DCVAL
+********       MNOTE 'DCVAL(''a''''''''b&&c'')=>&DCVAL<  length = &K'
+ AGO .JJG3
+         AIF   ('&DCVAL' NE 'a''b&&c').DCVERR
+*
+&DCVAL   SETC  DCVAL('&&&&'.'''''''')    string is "&&''"
+&K       SETA  K'&DCVAL
+*      MNOTE 'DCVAL(''&&&&&&&&''.'''''''''''''''')=&DCVAL  length = &K'
+         AIF   ('&DCVAL' NE '&&&&''''').DCVERR
+.JJG3 ANOP
+*----------------------------------------------------------------------
+*        z390 tests
+
+&DCVSTR  SETC  '''''&&&&1'''''              string "''&&1''" len 7
+&DCVAL   SETC  DCVAL('&DCVSTR')
+         MNOTE 'DCVAL(''&DCVSTR'')=&DCVAL'
+         AIF   ('&DCVAL' NE '''&&1''').DCVERR
+*----------------------------------------------------------------------
+         MNOTE '********** End   DCVAL tests **********'
+.SKPDCVO ANOP
+*======================================================================
+         AGO   .SKPDEQO    DEQUOTE tests now done in rt/mlc/TOPR2.MLC
+         MNOTE '********** Begin DEQUOTE tests **********'
+*----------------------------------------------------------------------
+*        HLASM LR examples
+
+&DCESTR  SETC  '''ABC'''
+&DEQUOTE SETC  DEQUOTE('&DCESTR')
+         MNOTE 'DEQUOTE(''&DCESTR'')=&DEQUOTE'
+         AIF   ('&DEQUOTE' NE 'ABC').DCEERR
+          MNOTE 'Examples from HLASM LR' 
+&C       SETC  DEQUOTE('charstring') 
+         MNOTE '&&C       SETC  DEQUOTE(''charstring''); &&C=&C'
+         AIF   ('&C' NE 'charstring').DCEERR 
+&C       SETC  DEQUOTE('') 
+         MNOTE '&&C       SETC  DEQUOTE(''''); &&C=&C' 
+         AIF   (K'&C NE 0).DCEERR 
+&C       SETC  DEQUOTE('a') 
+         MNOTE '&&C       SETC  DEQUOTE(''a''); &&C=&C' 
+         AIF   ('&C' NE 'a').DCEERR 
+&ARG     SETC  '''a''' 
+&C       SETC  DEQUOTE('&ARG') 
+         MNOTE '&&C       SETC  DEQUOTE(''&ARG''); &&C=&C' 
+         AIF   ('&C' NE 'a').DCEERR 
+&C       SETC  DEQUOTE('a''b') 
+         MNOTE '&&C       SETC  DEQUOTE(''a''''b''); &&C=&C' 
+         AIF   ('&C' NE 'a''b').DCEERR 
+&ARG     SETC  '''''' 
+&C       SETC  DEQUOTE('&ARG') 
+         MNOTE '&&C       SETC  DEQUOTE(''&ARG''); &&C=&C' 
+         AIF   (K'&C NE 0).DCEERR 
+.SKPDC ANOP
+*----------------------------------------------------------------------
+         MNOTE '********** End   DEQUOTE tests **********'
+.SKPDEQO ANOP
+*======================================================================
+         MBOX  'Test ISBIN, ISDEC, ISHEX, ISSYM'
+*AGO .SKPIS
+*======================================================================
+         MNOTE '********** Begin ISBIN tests **********'
+*----------------------------------------------------------------------
+*        HLASM LR examples
+
+&ISBIN   SETA  ISBIN('10101') 
+         MNOTE 'ISBIN(''10101'')=&ISBIN' 
+         AIF   (&ISBIN NE 1).ISERR 
+&ISBIN   SETA  ISBIN('101010101010101010101010101010101') excess digits
+         MNOTE 'ISBIN(''101010101010101010101010101010101'')=&ISBIN' 
+         AIF   (&ISBIN NE 0).ISERR 
+&ISBIN   SETA  ISBIN('12121')                         non-binary digits
+         MNOTE 'ISBIN(''12121'')=&ISBIN' 
+         AIF   (&ISBIN NE 0).ISERR
+***********************************************************************
+*        TODO: Next test now produces
+*                MNOTE 8,'ISBIN invalid operand value; length is zero'
+*              on z390, as it should. Need to add test to error tests
+* 
+*ISBIN   SETA  ISBIN('')                              error condition 
+*        MNOTE 'ISBIN('''')=&ISBIN' 
+*        AIF   (&ISBIN NE 0).ISERR 
+*----------------------------------------------------------------------
+*        z390 tests
+
+&ISBIN   SETA  ISBIN('100')
+         MNOTE 'ISBIN(''100'')=&ISBIN' 
+         AIF   (&ISBIN NE 1).ISERR 
+&ISBIN   SETA  ISBIN('+100')                           non-bin char 
+         MNOTE 'ISBIN(''+100'')=&ISBIN' 
+*         AIF   (&ISBIN NE 0).ISERR 
+&ISBIN   SETA  ISBIN('123') 
+         MNOTE 'ISBIN(''123'')=&ISBIN' 
+         AIF   (&ISBIN NE 0).ISERR
+&ISBIN   SETA  ISBIN('000000000000000000000000000000000') excess digits
+         MNOTE 'ISBIN(''000000000000000000000000000000000'')=&ISBIN' 
+         AIF   (&ISBIN NE 0).ISERR  
+*----------------------------------------------------------------------
+         MNOTE '********** End   ISBIN tests **********'
+*======================================================================
+         MNOTE '********** Begin ISDEC tests **********'
+*----------------------------------------------------------------------
+*        HLASM LR examples
+
+&ISDEC   SETA  ISDEC('12345678')               okay 
+         MNOTE 'ISDEC(''12345678'')=&ISDEC' 
+         AIF   (&ISDEC NE 1).ISERR 
+&ISDEC   SETA  ISDEC('+25')                    non-digit
+         MNOTE 'ISDEC(''+25'')=&ISDEC' 
+         AIF   (&ISDEC NE 0).ISERR 
+&ISDEC   SETA  ISDEC('2147483648')             too large 
+         MNOTE 'ISDEC(''2147483648'')=&ISDEC' 
+         AIF   (&ISDEC NE 0).ISERR 
+&ISDEC   SETA  ISDEC('00000000005')            too many digits; max 10
+         MNOTE 'ISDEC(''00000000005'')=&ISDEC' 
+         AIF   (&ISDEC NE 0).ISERR 
+***********************************************************************
+*        TODO: Next test now produces
+*                MNOTE 8,'ISDEC invalid operand value; length is zero'
+*              on z390, as it should. Need to add test to error tests
+* 
+*&ISDEC   SETA  ISDEC('')                      error condition
+*         MNOTE 'ISDEC('''')=&ISDEC' 
+*         AIF   (&ISDEC NE 0).ISERR
+*----------------------------------------------------------------------
+*        z390 tests
+
+&ISDEC   SETA  ISDEC('123') 
+         MNOTE 'ISDEC(''123'')=&ISDEC' 
+         AIF   (&ISDEC NE 1).ISERR 
+&ISDEC   SETA  ISDEC('-123')                   non-digit 
+         MNOTE 'ISDEC(''-123'')=&ISDEC' 
+         AIF   (&ISDEC NE 0).ISERR 
+&ISDEC   SETA  ISDEC('12A') 
+         MNOTE 'ISDEC(''12A'')=&ISDEC' 
+         AIF   (&ISDEC NE 0).ISERR 
+&ISDEC   SETA  ISDEC('00000000000')            too many digits; max 10
+         MNOTE 'ISDEC(''00000000000'')=&ISDEC' 
+         AIF   (&ISDEC NE 0).ISERR
+*----------------------------------------------------------------------
+         MNOTE '********** End   ISDEC tests **********'
+*======================================================================
+         MNOTE '********** Begin ISHEX tests **********'
+*----------------------------------------------------------------------
+*        HLASM LR examples
+
+&ISHEX   SETA  ISHEX('ab34CD9F') 
+         MNOTE 'ISHEX(''ab3fCD9F'')=&ISHEX' 
+         AIF   (&ISHEX NE 1).ISERR 
+&ISHEX   SETA  ISHEX('abcdEFGH') 
+         MNOTE 'ISHEX(''abcdEFGH'')=&ISHEX'    non-hexadecimal digits
+         AIF   (&ISHEX NE 0).ISERR 
+&ISHEX   SETA  ISHEX('123456789')              too many chars; 8 max 
+         MNOTE 'ISHEX(''123456789'')=&ISHEX' 
+         AIF   (&ISHEX NE 0).ISERR
+***********************************************************************
+*        TODO: Next test now produces
+*                MNOTE 8,'ISHEX invalid operand value; length is zero'
+*              on z390, as it should. Need to add test to error tests
+* 
+*&ISHEX   SETA  ISHEX('')                      error condition
+*         MNOTE 'ISHEX('''')=&ISHEX' 
+*         AIF   (&ISHEX NE 0).ISERR
+*----------------------------------------------------------------------
+*        z390 tests
+
+&ISHEX   SETA  ISHEX('F0') 
+         MNOTE 'ISHEX(''F0'')=&ISHEX' 
+         AIF   (&ISHEX NE 1).ISERR
+&ISHEX   SETA  ISHEX('+F0')                    non-hex char 
+         MNOTE 'ISHEX(''+F0'')=&ISHEX' 
+         AIF   (&ISHEX NE 0).ISERR 
+&ISHEX   SETA  ISHEX('FG') 
+         MNOTE 'ISHEX(''FG'')=&ISHEX' 
+         AIF   (&ISHEX NE 0).ISERR
+&ISHEX   SETA  ISHEX('000000000')              too many chars; 8 max
+         MNOTE 'ISHEX(''000000000'')=&ISHEX' 
+         AIF   (&ISHEX NE 0).ISERR
+*----------------------------------------------------------------------
+         MNOTE '********** End   ISHEX tests **********'
+*======================================================================
+         MNOTE '********** Begin ISSYM tests **********'
+*----------------------------------------------------------------------
+*        HLASM LR examples
+
+&ISSYM   SETA  ISSYM('Abcd_1234') 
+         MNOTE 'ISSYM(''Abcd_1234'')=&ISSYM' 
+         AIF   (&ISSYM NE 1).ISERR 
+&ISSYM   SETA  ISSYM('_Abcd1234') 
+         MNOTE 'ISSYM(''_Abcd1234'')=&ISSYM' 
+         AIF   (&ISSYM NE 1).ISERR 
+&ISSYM   SETA  ISSYM('##@$_') 
+         MNOTE 'ISSYM(''##@$_'')=&ISSYM' 
+         AIF   (&ISSYM NE 1).ISERR 
+&ISSYM   SETA  ISSYM('1234_Abcd')              invalid initial char
+         MNOTE 'ISSYM(''1234_Abcd'')=&ISSYM' 
+         AIF   (&ISSYM NE 0).ISERR
+***********************************************************************
+*        TODO: Next test now produces
+*                MNOTE 8,'ISSYM invalid operand value; length is zero'
+*              on z390, as it should. Need to add test to error tests
+* 
+*&ISSYM   SETA  ISSYM('')                      error condition
+*         MNOTE 'ISSYM('''')=&ISSYM' 
+*         AIF   (&ISSYM NE 0).ISERR
+*----------------------------------------------------------------------
+*        z390 tests
+
+&ISSYM   SETA  ISSYM('AZ090#$_') 
+         MNOTE 'ISSYM(''AZ090#$_'')=&ISSYM' 
+         AIF   (&ISSYM NE 1).ISERR 
+&ISSYM   SETA  ISSYM('AZ090#$_**') 
+         MNOTE 'ISSYM(''AZ090#$_**'')=&ISSYM' 
+         AIF   (&ISSYM NE 0).ISERR 
+.SKPIS ANOP
+*----------------------------------------------------------------------
+         MNOTE '********** End   ISSYM tests **********'
+***********************************************************************
+         MBOX  'Test AND, NOT, OR, XOR'
+*AGO .SKPLOG
+*======================================================================
+         MNOTE '********** Begin AND, NOT, OR, XOR tests **********'
+*----------------------------------------------------------------------
+*        HLASM LR examples
+
+&OP1     SETA  10 
+&OP2     SETA  6                              HLASM LR uses 2
+&BOP1    SETC  A2B(&OP1) 
+&BOP2    SETC  A2B(&OP2) 
+         MNOTE 'OP1 = &OP1 (B''&BOP1'')' 
+         MNOTE 'OP2 =  &OP2 (B''&BOP2'')' 
+* 
+&AND     SETA  (&OP1 AND &OP2) 
+&BAND    SETC  A2B(&AND) 
+         MNOTE '(&OP1 AND &OP2) = &AND (B''&BAND'')' 
+         AIF   (&AND NE 2).LOERR 
+&NOT     SETA  (NOT &OP1) 
+&SNOT    SETC  SIGNED(&NOT) 
+&BNOT    SETC  A2B(&NOT) 
+         MNOTE '(NOT &OP1) = &SNOT (B''&BNOT'')' 
+         AIF   (&NOT NE -11).LOERR 
+&OR      SETA  (&OP1 OR &OP2) 
+&BOR     SETC  A2B(&OR) 
+         MNOTE '(&OP1 OR &OP2) = &OR (B''&BOR'')' 
+         AIF   (&OR NE 14).LOERR 
+&XOR     SETA  (&OP1 XOR &OP2) 
+&BXOR    SETC  A2B(&XOR) 
+         MNOTE '(&OP1 XOR &OP2) = &XOR (B''&BXOR'')' 
+         AIF   (&XOR NE 12).LOERR 
+.SKPLOG  ANOP
+*----------------------------------------------------------------------
+         MNOTE '********** End   AND, NOT,OR, XOR tests **********'
+***********************************************************************
+         MBOX  'Test SIGNED, SYSATTRA, SYSATTRP'
+*AGO .SKPSSS
+*======================================================================
+         MNOTE '********** Begin SIGNED tests **********'
+*----------------------------------------------------------------------
+*        HLASM LR examples
+
+&SIGNED  SETC  SIGNED(10)
+         MNOTE 'SIGNED(10)=&SIGNED'
+         AIF   ('&SIGNED' NE '10').SIGNERR
+&SIGNED  SETC  SIGNED(-10)
+         MNOTE 'SIGNED(-10)=&SIGNED'
+         AIF   ('&SIGNED' NE '-10').SIGNERR
+*----------------------------------------------------------------------
+*        z390 tests
+
+&SIGNED  SETC  SIGNED(-241)
+         MNOTE 'SIGNED(-241)=&SIGNED'
+         AIF   ('&SIGNED' NE '-241').SIGNERR
+*----------------------------------------------------------------------
+         MNOTE '********** End   SIGNED tests **********'
+*======================================================================
+         MNOTE '********** Begin SYSATTRA, SYSATTRP tests **********'
+*----------------------------------------------------------------------
+*        z390 tests
+
+&SYSATTRA SETC  SYSATTRA('SYM')                 see HLASM LR p339
+         MNOTE 'SYSATTRA(''SYM'')=&SYSATTRA'
+         AIF   ('&SYSATTRA' NE 'GR32').SYERR
+&SYSATTRP SETC  SYSATTRP('SYM')                 see HLASM LR pp339-340
+         MNOTE 'SYSATTRP(''SYM'')=&SYSATTRP'
+         AIF   ('&SYSATTRP' NE 'PGMA').SYERR
+.SKPSSS ANOP
+*----------------------------------------------------------------------
+         MNOTE '********** End   SYSATTRA, SYSATTRP tests **********'
+***********************************************************************
+         MBOX  'Test SLA, SLL, SRA, SRL'
+*AGO .SKPSHFT
+*======================================================================
+         MNOTE '********** Begin SLA tests **********'
+*----------------------------------------------------------------------
+*        HLASM LR examples
+
+&OP1S    SETA  2
+&OP2S    SETA  2
+
+&SLA     SETA  (&OP1S SLA &OP2S)
+         MNOTE '(&OP1S SLA &OP2S) = &SLA'
+         AIF   (&SLA NE 8).SLAERR
+*----------------------------------------------------------------------
+*        z390 tests
+
+&SLA     SETA  (1 SLA 2)
+         MNOTE '(1 SLA 2) = &SLA'
+         AIF   (&SLA NE 4).SLAERR
+&SLA     SETA  (X'3FFFFFFF' SLA 1)
+         MNOTE '(X''3FFFFFFF'' SLA 1) = &SLA'
+         AIF   (&SLA NE X'7FFFFFFE').SLAERR
+***********************************************************************
+*         TODO: Next 2 tests result in arithmetic overflow
+*               Create error tests
+*
+*&SLA     SETA  (X'7FFFFFFF' SLA 1)            ASMA075E arith overflow
+*         MNOTE '(X''7FFFFFFF'' SLA 1) = &SLA'
+*         AIF   (&SLA NE X'7FFFFFFE').SLAERR
+*&SLA     SETA  (X'80000001' SLA 1)            ASMA075E arith overflow
+*         MNOTE '(X''80000001'' SLA 1) = &SLA'
+*         AIF   (&SLA NE X'80000002').SLAERR
+&SLA     SETA  (X'C0000001' SLA 1)             okay
+&SSLA    SETC  (SIGNED &SLA)
+&XSLA    SETC  A2X(&SLA)
+         MNOTE '(X''C0000001'' SLA 1) = &SSLA (X''&XSLA'')'
+         AIF   (&SLA NE X'80000002').SLAERR
+*----------------------------------------------------------------------
+         MNOTE '********** End   SLA tests **********'
+*======================================================================
+         MNOTE '********** Begin SLL tests **********'
+*----------------------------------------------------------------------
+*        HLASM LR examples
+
+&OP1S    SETA  10
+&OP2S    SETA  2
+
+&SLL     SETA  (&OP1S SLL &OP2S)
+         MNOTE '(&OP1S SLL &OP2S) = &SLL'
+         AIF   (&SLL NE 40).SLLERR
+*----------------------------------------------------------------------
+*        z390 tests
+
+&SLL     SETA  (1 SLL 2)
+         MNOTE '(1 SLL 2) = &SLL'
+         AIF   (&SLL NE 4).SLLERR
+&SLL     SETA  (X'7FFFFFFF' SLL 1)
+&SSLL    SETC  (SIGNED &SLL)
+&XSLL    SETC  A2X(&SLL)
+         MNOTE '(X''7FFFFFFF'' SLL 1) = &SSLL (X''&XSLL'')'
+         AIF   (&SLL NE X'FFFFFFFE').SLLERR
+*----------------------------------------------------------------------
+         MNOTE '********** End   SLL tests **********'
+*======================================================================
+         MNOTE '********** Begin SRA tests **********'
+*----------------------------------------------------------------------
+*        HLASM LR examples
+
+&OP1S    SETA  10
+&OP2S    SETA  2
+
+&SRA     SETA  (&OP1S SRA &OP2S)
+         MNOTE '(&OP1S SRA &OP2S) = &SRA'
+         AIF   (&SRA NE 2).SRAERR
+
+&OP1S    SETA  -344
+&OP2S    SETA  40
+
+&SRA     SETA  (&OP1S SRA &OP2S)
+&SSRA    SETC  (SIGNED &SRA)
+&SOP1S   SETC  (SIGNED &OP1S)
+         MNOTE '(&SOP1S SRA &OP2S) = &SSRA'
+         AIF   (&SRA NE -1).SRAERR
+ 
+&XSRA    SETC  A2X(&SRA) 
+&XOP1S   SETC  A2X(&OP1S) 
+         MNOTE '(X''&XOP1S'' SRA &OP2S) = &SSRA (X''&XSRA'')'
+*----------------------------------------------------------------------
+*        z390 tests
+
+&SRA     SETA  (4 SRA 2)
+         MNOTE '(4 SRA 2) = &SRA'
+         AIF   (&SRA NE 1).SRAERR
+&SRA     SETA  (X'FFFFFFFE' SRA 1)
+&SSRA    SETC  (SIGNED &SRA)
+         MNOTE '(X''FFFFFFFE'' SRA 1) = &SSRA'
+         AIF   (&SRA NE X'FFFFFFFF').SRAERR
+*----------------------------------------------------------------------
+         MNOTE '********** End   SRA tests **********'
+*======================================================================
+         MNOTE '********** Begin SRL tests **********'
+*----------------------------------------------------------------------
+*        HLASM LR examples
+
+&OP1S    SETA  10
+&OP2S    SETA  2
+
+&SRL     SETA  (&OP1S SRL &OP2S)
+         MNOTE '(&OP1S SRL &OP2S) = &SRL'
+         AIF   (&SRL NE 2).SRLERR
+
+&OP1S    SETA  -344
+&OP2S    SETA  40
+
+&SRL     SETA  (&OP1S SRL &OP2S)
+&SSRL    SETC  (SIGNED &SRL)
+&SOP1S   SETC  (SIGNED &OP1S)
+         MNOTE '(&SOP1S SRL &OP2S) = &SSRL'
+         AIF   (&SRL NE 0).SRLERR
+*----------------------------------------------------------------------
+*        z390 tests
+
+&SRL     SETA  (4 SRL 2)
+         MNOTE '(4 SRL 2) = &SRL'
+         AIF   (&SRL NE 1).SRLERR
+&SRL     SETA  (X'FFFFFFFE' SRL 1)
+&XSRL    SETC  A2X(&SRL)
+         MNOTE '(X''FFFFFFFE'' SLL 1) = &SRL (X''&XSRL'')'
+         AIF   (&SRL NE X'7FFFFFFF').SRLERR
+.SKPSHFT ANOP
+*----------------------------------------------------------------------
+         MNOTE '********** End   SRL tests **********'
+***********************************************************************
+         MBOX  'Test operator types A,E,M,O,S,U'
+*AGO .SKPOT
+&OT      SETC  O'PUSH 
+         MNOTE 'O''PUSH = &OT' 
+         AIF   (O'PUSH      NE 'A').OTERR  Assembler code 
+&OT      SETC  O'BER 
+         MNOTE 'O''BER = &OT' 
+         AIF   (O'BER       NE 'E').OTERR  Extended mnemonic code
+&OT      SETC  O'BE 
+         MNOTE 'O''BE = &OT' 
+         AIF   (O'BE        NE 'E').OTERR  Extended mnemonic code
+&OT      SETC  O'JE 
+         MNOTE 'O''JE = &OT' 
+         AIF   (O'JE        NE 'E').OTERR  Extended mnemonic code
+&OT      SETC  O'SRNM 
+         MNOTE 'O''SRNM = &OT' 
+         AIF   (O'SRNM      NE 'O').OTERR  Machine code 
+&OT      SETC  O'BCR 
+         MNOTE 'O''BCR = &OT' 
+         AIF   (O'BCR       NE 'O').OTERR  Machine code 
+&OT      SETC  O'BC 
+         MNOTE 'O''BC = &OT' 
+         AIF   (O'BC        NE 'O').OTERR  Machine code 
+&OT      SETC  O'BRC 
+         MNOTE 'O''BRC = &OT' 
+         AIF   (O'BRC       NE 'O').OTERR  Machine code 
+&OT      SETC  O'SAVE 
+         MNOTE 'O''SAVE = &OT' 
+         AIF   (O'SAVE      NE 'S').OTERR  Library macro found
+&OT      SETC  O'RETURN
+         MNOTE 'O''RETURN = &OT' 
+         AIF   (O'RETURN    NE 'M').OTERR  Loaded macro  
+&OT      SETC  O'XXXXX 
+         MNOTE 'O''XXXXX = &OT' 
+         AIF   (O'XXXXX     NE 'U').OTERR  Undefined 
+.SKPOT ANOP
+***********************************************************************
+         MBOX  'Test string duplication in expression'
+&A       SETC  'A'
+         AIF   ('&A'.(2)'B' NE 'ABB').DUPERR
+         AIF   ('A'.(2)'B' NE 'ABB').DUPERR
+***********************************************************************
+         MBOX  'Test FIND, INDEX'
+*======================================================================
+         MNOTE '********** Begin FIND tests **********'
+*----------------------------------------------------------------------
+*        HLASM LR examples
+
+&OP1F    SETC  'abcdef'
+&OP2F    SETC  'cde'                           order irrelevant
+&VARF    SETA   ('&OP1F' FIND '&OP2F')
+         MNOTE '''&OP1F'' FIND ''&OP2F'''
+         MNOTE '&&VARF=&VARF'
+         AIF   (&VARF NE 3).FINDERR            finds 'c' in 'abcdef'
+
+&OP1F    SETC  'abcdef' 
+&OP2F    SETC  'gde' 
+&VARF    SETA   ('&OP1F' FIND '&OP2F') 
+         MNOTE '''&OP1F'' FIND ''&OP2F''' 
+         AIF   (&VARF NE 4).FINDERR            finds 'd' in 'abcdef'
+                                                                    
+&OP1F    SETC  'abcdef' 
+&OP2F    SETC  'egd' 
+&VARF    SETA   ('&OP1F' FIND '&OP2F') 
+         MNOTE '''&OP1F'' FIND ''&OP2F''' 
+         AIF   (&VARF NE 4).FINDERR            finds 'd' in 'abcdef'
+*----------------------------------------------------------------------
+*        z390 tests
+
+&IX      SETA  FIND('abc','b')
+         MNOTE 'IX=&IX'
+         AIF   (&IX NE 2).FINDERR
+&IX      SETA  FIND('abc','xb')
+         MNOTE 'IX=&IX'
+         AIF   (&IX NE 2).FINDERR
+&IX      SETA  FIND('abc','cb')
+         MNOTE 'IX=&IX'
+         AIF   (&IX NE 2).FINDERR
+&IX      SETA  FIND('abc','d')
+         MNOTE 'IX=&IX'
+         AIF   (&IX NE 0).FINDERR
+&IX      SETA  FIND('abc','d')
+         MNOTE 'IX=&IX'
+         AIF   (&IX NE 0).FINDERR
+*----------------------------------------------------------------------
+         MNOTE '********** End   FIND tests **********'
+***********************************************************************
+*======================================================================
+         MNOTE '********** Begin INDEX tests **********'
+*----------------------------------------------------------------------
+*        HLASM LR examples
+
+&IX      SETA  INDEX('ABC','B')
+         MNOTE 'IX=&IX'
+         AIF   (&IX NE 2).INDXERR
+&IX      SETA  INDEX('ABC','D')
+         MNOTE 'IX=&IX'
+         AIF   (&IX NE 0).INDXERR
+*----------------------------------------------------------------------
+*        z390 tests
+
+&IX      SETA  INDEX('ABXBC','BC')
+         MNOTE 'IX=&IX'
+         AIF   (&IX NE 4).INDXERR
+&IX      SETA  INDEX('ABC','D')
+         MNOTE 'IX=&IX'
+         AIF   (&IX NE 0).INDXERR
+&IX      SETA  INDEX('ABC','ABC')
+         MNOTE 'IX=&IX'
+         AIF   (&IX NE 1).INDXERR
+&IX      SETA  INDEX('ABC','ABCD')
+         MNOTE 'IX=&IX'
+         AIF   (&IX NE 0).INDXERR
+*----------------------------------------------------------------------
+         MNOTE '********** End   INDEX tests **********'
+***********************************************************************
+         AGO   .LOOP
+.ENDLOOP ANOP
+         MNOTE '*********************************************'
+         MNOTE 'TESTOPR2 MNOTE,AIF section ended successfully'
+         MNOTE '*********************************************'
+         AGO   .EXIT
+***********************************************************************
+*        Error MNOTEs
+***********************************************************************
+.LCERR   ANOP
+         MNOTE 12,'LOWER CASE TEST ERROR'
+         AGO   .EXIT
+.UCERR   ANOP
+         MNOTE 12,'UPPER CASE TEST ERROR'
+         AGO   .EXIT
+.A2ERR   ANOP
+         MNOTE 12,'A2 OPERATOR ERROR'
+         AGO   .EXIT
+.B2ERR   ANOP
+         MNOTE 12,'B2 OPERATOR ERROR'
+         AGO   .EXIT
+.C2ERR   ANOP
+         MNOTE 12,'C2 OPERATOR ERROR'
+         AGO   .EXIT
+.D2ERR   ANOP
+         MNOTE 12,'D2 OPERATOR ERROR'
+         AGO   .EXIT
+.X2ERR   ANOP
+         MNOTE 12,'X2 OPERATOR ERROR'
+         AGO   .EXIT
+.DCLERR  ANOP
+         MNOTE 12,'DCLEN OPERATOR ERROR'
+         AGO   .EXIT
+.DCVERR  ANOP
+         MNOTE 12,'DCVAL OPERATOR ERROR'
+         AGO   .EXIT
+.DCEERR  ANOP
+         MNOTE 12,'DCEQUOTE OPERATOR ERROR'
+         AGO   .EXIT
+.ISERR   ANOP
+         MNOTE 12,'IS??? OPERATOR ERROR'
+         AGO   .EXIT
+.LOERR   ANOP
+         MNOTE 12,'LOGIC OPERATOR ERROR'
+         AGO   .EXIT
+.SIGNERR ANOP
+         MNOTE 12,'SIGNED OPERATOR ERROR'
+         AGO   .EXIT
+.SYERR   ANOP
+         MNOTE 12,'SYSATTR A/P OPERATOR ERROR'
+         AGO   .EXIT
+.SLAERR  ANOP
+         MNOTE 12,'SLA OPERATOR ERROR'
+         AGO   .EXIT
+.SLLERR  ANOP
+         MNOTE 12,'SLL OPERATOR ERROR'
+         AGO   .EXIT
+.SRAERR  ANOP
+         MNOTE 12,'SRA OPERATOR ERROR'
+         AGO   .EXIT
+.SRLERR  ANOP
+         MNOTE 12,'SRL OPERATOR ERROR'
+         AGO   .EXIT
+.OTERR   ANOP
+         MNOTE 12,'OPERATION TYPE TEST ERROR'
+         AGO   .EXIT
+.DUPERR  ANOP
+         MNOTE 12,'DUPLICATION TYPE TEST ERROR'
+         AGO   .EXIT
+.FINDERR ANOP
+         MNOTE 12,'FIND ERROR'
+         AGO   .EXIT
+.INDXERR ANOP
+         MNOTE 12,'INDEX ERROR'
+         AGO   .EXIT
+.EXIT    ANOP
+*
+         END

--- a/rt/test/TESTOPR2.MLC
+++ b/rt/test/TESTOPR2.MLC
@@ -104,7 +104,7 @@
 *----------------------------------------------------------------------
 *
 * Registers on entry:
-*     R15  emtry point
+*     R15  entry point
 *     R14  return address
 *     R13  usable save area
 *

--- a/src/az390.java
+++ b/src/az390.java
@@ -422,6 +422,7 @@ public  class  az390 implements Runnable {
 		* 2022-10-24 jjg #451 z390 ignores CODEPAGE option for input;
 		*                     replace non-printable with '.' in PRN, BAL, PCH
         * 2024-05-29 afk #500 List suboption for options optable/machine not implemented correctly
+        * 2024-07-03 jjg #509 generate error in process_dcc_data if "DC  C''"
 	*****************************************************
     * Global variables                        last rpi
     *****************************************************/
@@ -9414,20 +9415,24 @@ private void process_dcc_data(){
 	}
 	dc_index = dc_index + dcc_next + 1;
 	dcc_len = dcc_text.length();
-	dcc_ascii_req = 
-		 (dcc_quote == '\'' 
-			 && (    (tz390.opt_ascii 
-				      && dc_type_sfx != 'E'
-				     )
-				  || dc_type_sfx == 'A'
-				)
-         )
-	     | dcc_quote == '"';  //RPI5 and RPI73
-	if (dc_bit_len){
-		gen_dcc_bits();
-	} else {
-		gen_dcc_bytes();
-	}
+	if (dcc_len > 0 || dc_len_explicit) {                            // #509
+		dcc_ascii_req = 
+			 (dcc_quote == '\'' 
+				 && (    (tz390.opt_ascii 
+					      && dc_type_sfx != 'E'
+					     )
+					  || dc_type_sfx == 'A'
+					)
+    	     )
+		     | dcc_quote == '"';  //RPI5 and RPI73
+		if (dc_bit_len){
+			gen_dcc_bits();
+		} else {
+			gen_dcc_bytes();
+		}
+	} else {                                                         // #509
+		log_error(88,"invalid data field expression - " + dc_field); // #509
+	}                                                                // #509
 	dc_len = 0;
 }
 private void gen_dcc_bits(){

--- a/src/mz390.java
+++ b/src/mz390.java
@@ -12306,7 +12306,7 @@ public  class  mz390 {
     	check_setc_quotes(1); // RPI 1139
 		setc_value1 = get_setc_stack_value();
 		if (setc_value1.length() == 0) {                                     // #509
-			// HLASM LR states this case indicates an error.                 // #509
+			// HLASM LangRef states this case indicates an error.            // #509
 			// HLASM does not produce an error; returns 0.                   // #509
 			// Comment next line so z390 matches HLASM behavior              // #509
 			//create_mnote(8,"D2A invalid operand value; length is zero");   // #509
@@ -12355,7 +12355,7 @@ public  class  mz390 {
     	check_setc_quotes(1); // RPI 1139
 		setc_value1 = get_setc_stack_value();
 		if (setc_value1.length() == 0) {                                             // #509
-			// HLASM LR states this case indicates an error.                         // #509
+			// HLASM LangRef states this case indicates an error.                    // #509
 			// HLASM does not produce an error; returns empty string.                // #509
 			// Comment next line so z390 matches HLASM behavior                      // #509
 			//create_mnote(8,"D2C invalid operand value; length is zero");           // #509
@@ -12385,7 +12385,7 @@ public  class  mz390 {
     	check_setc_quotes(1); // RPI 1139
 		setc_value1 = get_setc_stack_value();                                            // #509
 		if (setc_value1.length() == 0) {                                                 // #509
-			// HLASM LR states this case indicates an error.                             // #509
+			// HLASM LangRef states this case indicates an error.                        // #509
 			// HLASM does not produce an error; returns empty string.                    // #509
 			// Comment next line so z390 matches HLASM behavior                          // #509
 			//create_mnote(8,"D2X invalid operand value; length is zero");               // #509
@@ -12682,7 +12682,7 @@ public  class  mz390 {
 		put_seta_stack_var();                                        // #509
     }
 	/**
-	 * Implement HLASM LR SLA built-in function                      // #509
+	 * Implement HLASM LangRef SLA built-in function                 // #509
 	 * 
 	 * @param x the number to shift
 	 * @param n the number of bits to shift
@@ -13026,7 +13026,7 @@ public  class  mz390 {
 			}
     		if  (text.length() < tz390.bal_ictl_end + 1){ // RPI 264, RPI 437 RPI 728
     			tz390.systerm_io++;
-				// HLASM LR says PUNCH can write all 256 EBCDIC characters.
+				// HLASM LangRef says PUNCH can write all 256 EBCDIC characters.
 				// Decide if put_bal_line keeps non-printable text.
 				file_buff.write(text_work + tz390.newline); // RPI 500
     		} else {

--- a/z390test/src/test/groovy/org/z390/test/RunHLASMBuiltInFunctionsTests.groovy
+++ b/z390test/src/test/groovy/org/z390/test/RunHLASMBuiltInFunctionsTests.groovy
@@ -24,7 +24,7 @@ class RunHLASMBuiltInFunctionsTests extends z390Test {
 
         // File containing report of tests done
         
-        this.env.put('REPORT', basePath('rt', 'mlc', 'TOPR2.TXT'))
+        this.env.put('REPORT', basePath('rt', 'mlc', 'TOPR2.TST'))
         
         int rc = this.asmlg(basePath("rt", "mlc", "TOPR2"), *options)
         this.printOutput()

--- a/z390test/src/test/groovy/org/z390/test/RunHLASMBuiltInFunctionsTests.groovy
+++ b/z390test/src/test/groovy/org/z390/test/RunHLASMBuiltInFunctionsTests.groovy
@@ -9,7 +9,6 @@ class RunHLASMBuiltInFunctionsTests extends z390Test {
      */
      
     var options = ["SYSMAC(${basePath("mac")})"]
-    var os = System.getProperty("os.name")
 
     @Test
     void test_TESTOPR2() {
@@ -28,7 +27,7 @@ class RunHLASMBuiltInFunctionsTests extends z390Test {
         
         // Where report of test done using code is written
         
-        this.env.put('REPORT', basePath('rt', 'mlc', 'TOPR2.TXT'))
+        this.env.put('REPORT', basePath('rt', 'mlc', 'TOPR2.TST'))
         
         int rc = this.asmlg(basePath("rt", "mlc", "TOPR2"), *options)
         this.printOutput()

--- a/z390test/src/test/groovy/org/z390/test/RunHLASMBuiltInFunctionsTests.groovy
+++ b/z390test/src/test/groovy/org/z390/test/RunHLASMBuiltInFunctionsTests.groovy
@@ -1,0 +1,33 @@
+package org.z390.test
+
+import org.junit.jupiter.api.Test
+
+class RunHLASMBuiltInFunctionsTests extends z390Test {
+
+    /*
+     * Test the High Level Assembler built-in functions
+     */
+     
+    var options = ["SYSMAC(${basePath("mac")})"]
+    var os = System.getProperty("os.name")
+
+    @Test
+    void test_TESTOPR2() {
+        
+        int rc = this.asmlg(basePath("rt", "test", "TESTOPR2"), *options)
+        this.printOutput()
+        assert rc == 0
+    }
+    
+    @Test
+    void test_TOPR2() {
+
+        // File containing report of tests done
+        
+        this.env.put('REPORT', basePath('rt', 'mlc', 'TOPR2.TXT'))
+        
+        int rc = this.asmlg(basePath("rt", "mlc", "TOPR2"), *options)
+        this.printOutput()
+        assert rc == 0
+    }
+}

--- a/z390test/src/test/groovy/org/z390/test/RunHLASMBuiltInFunctionsTests.groovy
+++ b/z390test/src/test/groovy/org/z390/test/RunHLASMBuiltInFunctionsTests.groovy
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test
 class RunHLASMBuiltInFunctionsTests extends z390Test {
 
     /*
-     * Test the High Level Assembler built-in functions
+     * Test the High Level Assembler (HLASM) built-in functions
      */
      
     var options = ["SYSMAC(${basePath("mac")})"]
@@ -13,6 +13,8 @@ class RunHLASMBuiltInFunctionsTests extends z390Test {
 
     @Test
     void test_TESTOPR2() {
+        
+        // Tests that use MNOTE, AIF to check results; no errors
         
         int rc = this.asmlg(basePath("rt", "test", "TESTOPR2"), *options)
         this.printOutput()
@@ -22,12 +24,94 @@ class RunHLASMBuiltInFunctionsTests extends z390Test {
     @Test
     void test_TOPR2() {
 
-        // File containing report of tests done
+        // Tests that use code to check results; no errors
         
-        this.env.put('REPORT', basePath('rt', 'mlc', 'TOPR2.TST'))
+        // Where report of test done using code is written
+        
+        this.env.put('REPORT', basePath('rt', 'mlc', 'TOPR2.TXT'))
         
         int rc = this.asmlg(basePath("rt", "mlc", "TOPR2"), *options)
         this.printOutput()
         assert rc == 0
+    }
+    
+    @Test
+    void test_C2BDX00() {
+
+        // Tests for C2B. C2D. C2X with X'00' in argument; no errors
+        
+        int rc = this.asm(basePath("rt", "mlc", "C2BDX00"), *options)
+        this.printOutput()
+        assert rc == 0
+    }
+    
+    @Test
+    void test_A2BE1() {
+
+        // Error tests for A2B; 1 invalid self-defining term; rc = 12
+        
+        int rc = this.asm(basePath("rt", "mlc", "A2BE1"), *options)
+        this.printOutput()
+        assert rc == 12
+    }
+    
+    @Test
+    void test_A2BE2() {
+
+        // Error tests for A2B; 1 arithmetic overflow; rc = 12
+        
+        int rc = this.asm(basePath("rt", "mlc", "A2BE2"), *options)
+        this.printOutput()
+        assert rc == 12
+    }
+    
+    @Test
+    void test_ISBINE1() {
+
+        // Error tests for ISBIN; 1 invalid operand value - length is 0; rc = 8
+        
+        int rc = this.asm(basePath("rt", "mlc", "ISBINE1"), *options)
+        this.printOutput()
+        assert rc == 8
+    }
+    
+    @Test
+    void test_ISDECE1() {
+
+        // Error tests for ISDEC; 1 invalid operand value - length is 0; rc = 8
+        
+        int rc = this.asm(basePath("rt", "mlc", "ISDECE1"), *options)
+        this.printOutput()
+        assert rc == 8
+    }
+    
+    @Test
+    void test_ISHEXE1() {
+
+        // Error tests for ISHEX; 1 invalid operand value - length is 0; rc = 8
+        
+        int rc = this.asm(basePath("rt", "mlc", "ISHEXE1"), *options)
+        this.printOutput()
+        assert rc == 8
+    }
+    
+    @Test
+    void test_ISSYME1() {
+
+        // Error tests for ISSYM; 1 invalid operand value - length is 0; rc = 8
+        
+        int rc = this.asm(basePath("rt", "mlc", "ISSYME1"), *options)
+        this.printOutput()
+        assert rc == 8
+    }
+    
+    @Test
+    void test_SLAE1() {
+
+        // Error tests for SLA; 10 arithmetic overflows; rc = 8
+        
+        int rc = this.asm(basePath("rt", "mlc", "SLAE1"), *options)
+        this.printOutput()
+        assert rc == 8
     }
 }

--- a/zcobol/mac/GEN_MOVE.MAC
+++ b/zcobol/mac/GEN_MOVE.MAC
@@ -54,6 +54,7 @@
 .* 03/27/12 RPI 1182 support variable length RMD move
 .* 04/14/12 RPI 1202 use D2A to retrieve neg &NT_IX and &NS_IX
 .* 04/20/12 RPI 1211 scale value if pic_dec values different
+.* 2024/07/03 #509 correct length in &N_TARGET substring extraction
 .*********************************************************************
          GEN_MOVE &T_NAME,&T_IX,&S_NAME,&S_IX 
          COPY  ZC_WS
@@ -2014,7 +2015,7 @@
                    :&FIELD_OFF SETA D2A('&N_TARGET'(1,&I-1)) RPI 1139
                    :&J SETA ('&N_TARGET' INDEX ',')
                    AIF (&J GT &I+1)
-                       :&FIELD_LEN SETA D2A('&N_TARGET'(&I+1,&J-1)) 
+                       :&FIELD_LEN SETA D2A('&N_TARGET'(&I+1,&J-&I-1)) #509
                        :&FIELD_REG SETC '&N_TARGET'(&J+1,K'&N_TARGET-&JX
                -1)
                        :&N_TARGET SETC '&N_TARGET'(1,&I).'&N_TARGET'(&JX

--- a/zopcheck/ZOPMACRO.CPY
+++ b/zopcheck/ZOPMACRO.CPY
@@ -23,6 +23,7 @@
 * 2020/09/19 DSH RPI 2213 REMOVE TYPE DM, ADD DIAGNOSE/DIAG RS, SIE S
 * 2020/10/02 DSH RPI 2212 RESTORE TYPE_VRR FROM V1700, ADD VREGS 0-31
 * 2021/02/08 DSH RPI 2226 FIX VNOT TO GENERATE V3=V2 FOR VNOT V1,V2
+* 2024/04/26 jjg #509 fix bugs with X2A usage due to X2A changes
 ************************************************************
         GBLA &TOT_OPS,&TOT_MASK,&TOT_DUP,&TOT_UND
         GBLA &TOT_PROB,&TOT_SUPR,&TOT_MISSING
@@ -377,7 +378,11 @@
 &HEX	SETC	'&LAB'(3,2)
 &HEX2   SETC    '&LAB'(5,2)
 &HEX3   SETC    '&LAB_OP'(7,1)
+        AIF ('&HEX3' NE '_')                       #509
 &M3     SETA    X2A('&HEX3')
+        AELSE                                      #509
+&M3     SETA    0                                  #509
+        AEND                                       #509
       AIF (N'&SYSLIST EQ 4 AND '&HEX3' NE '_')
         GBLA    &TOT_MASK
 &TOT_MASK SETA &TOT_MASK+1
@@ -580,7 +585,11 @@ DC      X'&HEX',AL1(&P3*16+0,&P1*16+&P2)
          AELSE    SELGR R1,R2 OOOO3M12
           GBLA    &TOT_MASK
 &TOT_MASK SETA &TOT_MASK+1
+           AIF ('&LAB_OP'(7,1) NE '_')       #509
 &M3       SETA    X2A('&LAB_OP'(7,1))
+           AELSE                             #509
+&M3       SETA    0                          #509
+           AEND                              #509
 &LAB_OP ORG &OP_LAB+16 
  DC      X'&HEX',AL1(&P3*16+&M3,&P1*16+&P2)
  
@@ -1608,7 +1617,11 @@ DC      X'&HEX',AL1(&P3*16+0,&P1*16+&P2)
  DC X'&HEX',AL1(&V1*16+&V2),S(&P3),AL1(&M4*16+&VREG_RXB),X'&HEX2'
   	         AELSEIF ('&LAB'(3,4) EQ 'E736')
 			 VREGS VP1=&P1,VP2=&P2 // RPI 2212 VLM V1,V3,D2(B2),M4
+               AIF ('&LAB'(7,1) NE '_')          #509
 &M3 SETA X2A('&LAB'(7,1))
+               AELSE                             #509
+&M3 SETA 0                                       #509
+               AEND                              #509
 &LAB_OP&LAB_OP ORG &OP_LAB+16
  DC X'&HEX',AL1(&V1*16+&V2),S(&P3),AL1(&M3*16+&VREG_RXB),X'&HEX2'
    	         AELSEIF ('&LAB'(3,4) EQ 'E738' OR '&LAB'(3,4) EQ 'E73A')
@@ -1622,7 +1635,11 @@ DC      X'&HEX',AL1(&P3*16+0,&P1*16+&P2)
  DC X'&HEX',AL1(&V1*16+&P2),S(&P3),AL1(&VREG_RXB),X'&HEX2'
      	         AELSEIF ('&LAB'(3,4) EQ 'E73E')
 	VREGS VP1=&P1,VP2=&P2 // RPI 2212 VSTM V1,V3,D2(B2) RPI 2216
+               AIF ('&LAB'(7,1) NE '_')          #509
 &M4 SETA X2A('&LAB'(7,1))
+               AELSE                             #509
+&M4 SETA 0                                       #509
+               AEND                              #509
 &LAB_OP&LAB_OP ORG &OP_LAB+16
  DC X'&HEX',AL1(&V1*16+&V2),S(&P3),AL1(&M4*16+&VREG_RXB),X'&HEX2'
       	        AELSEIF ('&LAB'(3,4) EQ 'E730')


### PR DESCRIPTION
Many of the z390 implementations of the HLASM built-in functions have errors. This PR fixes all errors found. The regression test programs added, rt/mlc/TOPR2.MLC and rt/test/TESTOPR2.MLC, test all the functions but do not test error conditions. This has been done outside of Git and will be added to the tests in Git at a future date. In additoin, due to a Git text restricton -- no null (X;00') characters in text -- some tests are not part of the tests at this time, although they have been done outside of Git.