### PR TITLE
Correct version number used in z390 distribution builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ jobs:
       - name: Checkout main
         uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           fetch-tags: true
       - name: version
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,9 +9,9 @@ jobs:
       VERSION: ${{ steps.version.outputs.VERSION }}
     steps:
       - name: Checkout main
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-tags: true
       - name: version
         run: |
           VERSION=$(git describe --tags)
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-distribution
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
@@ -58,7 +58,7 @@ jobs:
     needs:
       - build-distribution 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,6 @@ jobs:
     needs:
       - build-distribution 
     steps:
-      - uses: actions/checkout@v4
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'

--- a/bash/relver
+++ b/bash/relver
@@ -28,13 +28,13 @@ else
     if [ ${GIT_REPO} != 0 ]; then
         echo >&2 "Not a git repo.";
     else
-        $(git describe > /dev/null 2>&1)
+        $(git describe --tags > /dev/null 2>&1)
         GIT_DESCRIBE=$?
         if [ ${GIT_DESCRIBE} != 0 ]; then
             echo >&2 "Unable to git describe - fetching tags from upstream"
             get_tags
         fi
-        VER=$(git describe);
+        VER=$(git describe --tags);
     fi    
 fi
 


### PR DESCRIPTION
Fixes #600 
Some issues with retrieving git describe during build process. 
Have updated the actions to use new checkout action and added tag related options

Prior to change, the versions are inconsistent causing the issue.
![image](https://github.com/user-attachments/assets/1e54129b-d259-49ef-8dd4-c5b9a6c7a060)
In image, you see that the version stated in `Building z390 v1.8.3-a4`
Then later a `version=v1.8.1-59-g....`

I believe this was cause by inconstent use of `git describe`. The first uses the `--tags` option, the second does not.
Added `--tags` to the second call in bash/relver and now receiving consistent version numbers.

After change and new tag pushed
![image](https://github.com/user-attachments/assets/6ba13f99-b308-4250-b53b-8695f49ab166)
