### PR TITLE
Save test output if tests fail to aid diagnostics

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,12 @@ jobs:
           Z390_PROJECT_ROOT="../dist/z390_${VERSION}" z390test/gradlew -p z390test test 
         env:
           VERSION: ${{ needs.build-distribution.outputs.VERSION }}
+      - name: Upload z390Test output on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-output
+          path: ./z390test/build/z390test-output.txt
   
   run-windows-demo:
     runs-on: windows-latest

--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,8 @@ echo "::set-output name=javaversion::$(java -version)"
 # build the package
 bash/blddist "$@"
 
+# delete results output file
+rm -f ./z390test/build/z390test-output.txt
 # run the tests
 z390test/gradlew -p z390test cleanTest
 z390test/gradlew -p z390test test


### PR DESCRIPTION
Currently when the GitHub tests fail, there is no way to see the output of the tests that failed.

This PR will save the test job output as an GitHub actions artifact if the tests fail.
The test output will then be available to download from GitHub as part of the actions output.
Artifact name is `test-output`

![image](https://github.com/user-attachments/assets/9c6a22c7-b22a-4c0c-be53-f6d2b9d0c065)

New logic has been added to perform printOutput at the end of every test (no need to add to your tests).
The output from tests will be saved to file /z390Test/build/z390test-output.txt.

The change to automatically perform printOutput function at the end of each test means that current usage of this function is often not required at the end of a test. The code ignores when the function is called with no parameters.

If you want to get a snapshot of the output in the middle of a test, then you can still call printOutput - just make sure you include a label.