### PR TITLE
Fix CCW/CCW0/CCW1 with location counter reference in address field problem for issue 659

### DIFF
--- a/rt/bash/runasmtests
+++ b/rt/bash/runasmtests
@@ -21,6 +21,7 @@ bash/asmlg tests/TESTLITS trace noloadhigh $sysmac
 bash/asmlg tests/TEDIT    trace noloadhigh $sysmac $optable
 bash/asmlg rt/mlc/TESTAMPS trace noloadhigh $sysmac $optable
 bash/asmlg rt/mlc/IS215 trace noloadhigh $sysmac $optable
+bash/asmlg rt/mlc/IS659 trace noloadhigh $sysmac $optable
 bash/asmlg rt/mlc/TESTDC1  trace noloadhigh $sysmac $optable
 bash/asmlg rt/mlc/TESTASC1 ASCII trace noloadhigh $sysmac $optable
 bash/asmlg rt/mlc/TESTDC2  trace noloadhigh $sysmac $optable

--- a/rt/bat/RUNASMTESTS.BAT
+++ b/rt/bat/RUNASMTESTS.BAT
@@ -24,6 +24,7 @@ call bat\asmlg %z_TraceMode% tests\testlits  trace sysmac(mac) noloadhigh optabl
 call bat\asmlg %z_TraceMode% tests\TEDIT     trace sysmac(mac) noloadhigh optable(z390)       || goto error
 call bat\asmlg %z_TraceMode% rt\mlc\TESTAMPS trace sysmac(mac) noloadhigh optable(z390)       || goto error
 call bat\asmlg %z_TraceMode% rt\mlc\IS215    trace sysmac(mac) noloadhigh optable(z390)       || goto error
+call bat\asmlg %z_TraceMode% rt\mlc\IS659    trace sysmac(mac) noloadhigh optable(z390)       || goto error
 call bat\asmlg %z_TraceMode% rt\mlc\TESTDC1  trace sysmac(mac) noloadhigh optable(z390)       || goto error
 call bat\asmlg %z_TraceMode% rt\mlc\TESTASC1 trace sysmac(mac) noloadhigh optable(z390) ASCII || goto error
 call bat\asmlg %z_TraceMode% rt\mlc\TESTDC2  trace sysmac(mac) noloadhigh optable(z390)       || goto error

--- a/rt/mlc/IS659.MLC
+++ b/rt/mlc/IS659.MLC
@@ -1,0 +1,144 @@
+***********************************************************************
+* Test program for issue 659
+*
+* Problem reported was the "*-8" in the samples CCW, CCW1
+* shown below resulted in incorrect values -- 1 too large
+* for the CCW and 4 too large for the CCW1.
+*
+* Sample CCWs supplied by submitter of the issue
+***********************************************************************
+*
+IS659    CSECT ,
+         STM   14,12,12(13)        Save caller's registers
+         LR    12,15               R12 = base register
+         USING IS659,12            Establish addressability
+         LA    14,SA               Usable save area
+         ST    13,4(,14)           Chain
+         ST    14,8(,13)                 save areas
+         LR    13,14               Current save area
+*
+         SR    11,11               R11 will be return code
+         SR    10,10               Test number
+         LM    7,9,CCW@@           R7 -> 1st, R8 = len 1, R9 -> last
+LP1      DS    0H
+         AHI   10,1                Test number
+         LM    2,3,0(7)            2 -> CCW actual, 3 -> CCW expected
+         CLC   0(8,2),0(3)         actual : expected
+         BE    NX1                 If equal success; next test
+         WTO   'IS659 test failed; R10 = test number'
+         WTO   'IS769 R2 -> actual CCW, R3 -> expected CCW'
+         BAS   14,ErrMsg           Show error message ACT : EXP
+         LA    11,8                Error return code
+*         ABEND 101,DUMP            Don't continue
+NX1      DS    0H
+         BXLE  7,8,LP1             Do all tests
+*
+         LTR   11,11               All tests succeeded?
+         BZ    Success             Yes
+         WTO   'IS659 ERROR; at least one test failed'
+         B     Exit                Done
+Success  DS    0H
+         WTO   'IS659 all tests successfull'
+Exit     DS    0H
+         LR    15,11               Return code
+         L     13,4(,13)           Caller's save area
+         L     14,12(,13)          Restore caller's registers
+         LM    0,12,20(13)         ... except R15
+         BR    14                  Return to caller
+*
+* CCW COMMANDS:
+CCWCTIC  EQU   X'08'    TIC
+CCWCSEEK EQU   X'07'    SEEK
+CCWCSIDE EQU   X'31'    SEARCH ID EQUAL
+CCWCRDAT EQU   X'06'    READ DATA
+*
+* CCW FLAGS:
+CCWFCD   EQU   X'80'    CHAIN DATA
+CCWFCC   EQU   X'40'    CHAIN COMMAND
+CCWFSLI  EQU   X'20'    SUPPRESS INCORRECT LENGTH INDICATION
+CCWFSKIP EQU   X'10'    SKIP DATA TRANSFER ON RD/RDBK/SENSE 
+CCWFPCI  EQU   X'08'    PROGRAM CONTROLLED INTERRUPTION
+*
+* CCW/CCW0
+CCW      DS    0D
+         CCW   CCWCSEEK,SEEKADDR,CCWFCC,L'SEEKADDR
+SRCHID0  CCW   CCWCSIDE,BLKADDR,CCWFCC,L'BLKADDR
+         CCW   CCWCTIC,*-8,0,0
+         CCW   CCWCRDAT,BUFFER,CCWFSLI,L'BUFFER
+* CCW1
+CCW1     DS    0D
+         CCW1  CCWCSEEK,SEEKADDR,CCWFCC,L'SEEKADDR
+SRCHID1  CCW1  CCWCSIDE,BLKADDR,CCWFCC,L'BLKADDR
+         CCW1  CCWCTIC,*-8,0,0
+         CCW1  CCWCRDAT,BUFFER,CCWFSLI,L'BUFFER
+*
+SEEKADDR DS    XL6      BBCCHH
+BLKADDR  DS    XL5      CCHHR
+BUFFER   DS    CL80
+*
+SA       DC    18F'-1'
+*
+***********************************************************************
+* ErrMsg  Show actual CCW and expected CCW
+*
+* R2 -> actual CCW
+* R3 -> expected CCW
+* R13 usable save area
+* R14 return address
+***********************************************************************
+ErrMsg   DS    0H
+         STM   14,12,12(13)        Save caller's registers
+         UNPK  WA(9),0(5,2)        First half of doubleword
+         UNPK  WA+8(9),4(5,2)      Second half of doubleword
+         TR    WA,H2P              Finish conversion to printable hex
+         MVC   W1ACT,WA            Copy to WTO
+         UNPK  WA(9),0(5,3)        First half of doubleword
+         UNPK  WA+8(9),4(5,3)      Second half of doubleword
+         TR    WA,H2P              Finish conversion
+         MVC   W1EXP,WA            Copy to WTO
+         WTO   MF=(E,WTO1)         Issue WTO
+         LM    14,12,12(13)        Restore caller's registers
+         BR    14                  Return to caller
+*
+WTO1     WTO   'IS659E CCW ACT xxxxxxxxxxxxxxxx  EXP xxxxxxxxxxxxxxxx',X
+               MF=L
+W1ACT    EQU   WTO1+4+15,16,C'C'
+W1EXP    EQU   WTO1+4+37,16,C'C'
+*
+         DS    0D
+WA       DS    XL16,XL1            Work area to build prt hex dbl wd
+H2P      EQU   *-240               Convert to printable hex
+         DC    C'0123456789ABCDEF'
+*
+CCW@@    DC    A(CCW@,8,CCW@N,0)
+*
+CCW@     DS    0D
+         DC    A(CCW+0,CCWV+0)     A(actual CCW), A(expected CCW)
+         DC    A(CCW+8,CCWV+8)
+         DC    A(CCW+16,CCWV+16)
+         DC    A(CCW+24,CCWV+24)
+*
+         DC    A(CCW1+0,CCW1V+0)
+         DC    A(CCW1+8,CCW1V+8)
+         DC    A(CCW1+16,CCW1V+16)
+         DC    A(CCW1+24,CCW1V+24)
+***********************************************************************
+*        Put new entries above this line
+***********************************************************************
+CCW@N    EQU   *-8
+*
+CCWV     DS    0D
+      DC AL1(CCWCSEEK),AL3(SEEKADDR),AL1(CCWFCC),AL1(0),AL2(L'SEEKADDR)
+      DC AL1(CCWCSIDE),AL3(BLKADDR),AL1(CCWFCC),AL1(0),AL2(L'BLKADDR)
+      DC AL1(CCWCTIC),AL3(SRCHID0),AL1(0),AL1(0),AL2(0)
+      DC AL1(CCWCRDAT),AL3(BUFFER),AL1(CCWFSLI),AL1(0),AL2(L'BUFFER)
+*
+CCW1V    DS    0D
+         DC    AL1(CCWCSEEK),AL1(CCWFCC),AL2(L'SEEKADDR),AL4(SEEKADDR)
+         DC    AL1(CCWCSIDE),AL1(CCWFCC),AL2(L'BLKADDR),AL4(BLKADDR)
+         DC    AL1(CCWCTIC),AL1(0),AL2(0),AL4(SRCHID1)
+         DC    AL1(CCWCRDAT),AL1(CCWFSLI),AL2(L'BUFFER),AL4(BUFFER)
+*
+         LTORG ,
+*
+         END

--- a/src/az390.java
+++ b/src/az390.java
@@ -443,6 +443,8 @@ public  class  az390 implements Runnable {
     * 2025-05-30 AFK #631 Improve opcode table definitions
     * 2025-07-27 AFK      Add javadoc comments
     * 2025-08-08 AFK #661 Add z17 instructions to opcode tables
+    * 3025-09-17 jjg #659 CCW/CCW0/CCW1 with location counter reference in
+    *                     address field generates incorrect object code
   	*****************************************************
     * Global variables                        last rpi
     *****************************************************/
@@ -6017,8 +6019,10 @@ private void reduce_exp_rld(){
  *      for use in PRN display (i.e. show addresses
  *      relative to module versus CSECT).</li>
  * </ol>
+ *
+ * @param loc_ctr_offset offset from location counter for (relocatable) expression position  // #659
  */
-private void gen_exp_rld(){
+private void gen_exp_rld(int loc_ctr_offset){  // #659
 	if (cur_esd == 0 || sym_type[esd_sid[esd_base[cur_esd]]] != sym_cst){ // RPI 1208
 		return;
 	}        
@@ -6028,7 +6032,7 @@ private void gen_exp_rld(){
 	while (index < tot_exp_rld_add){
 		if (tot_rld < tz390.opt_maxrld){
 			rld_fld_esd[tot_rld] = esd_base[cur_esd]; // RPI 301
-			rld_fld_loc[tot_rld] = loc_ctr - sym_loc[esd_sid[esd_base[cur_esd]]]; // RPI 564 use base 
+			rld_fld_loc[tot_rld] = loc_ctr_offset + loc_ctr - sym_loc[esd_sid[esd_base[cur_esd]]]; // RPI 564 use base  // #659 
 			rld_fld_len[tot_rld] = exp_rld_len;
 			rld_fld_sgn[tot_rld] = rld_add;
 			rld_xrf_esd[tot_rld] = exp_rld_add_esd[index];
@@ -6051,7 +6055,7 @@ private void gen_exp_rld(){
 	while (index < tot_exp_rld_sub){
 		if (tot_rld < tz390.opt_maxrld){
 			rld_fld_esd[tot_rld] = cur_esd;
-			rld_fld_loc[tot_rld] = loc_ctr - sym_loc[esd_sid[cur_esd]]; 
+			rld_fld_loc[tot_rld] = loc_ctr_offset + loc_ctr - sym_loc[esd_sid[cur_esd]];  // #659 
 			rld_fld_len[tot_rld] = exp_rld_len;
 			rld_fld_sgn[tot_rld] = rld_sub;
 			rld_xrf_esd[tot_rld] = exp_rld_sub_esd[index];
@@ -7241,9 +7245,12 @@ private boolean calc_dca_exp(){
  *  <li>exp_index = index to terminator which can be end of string, or ()</li>
  * </ol>
  *
+ * @param loc_ctr_offset offset from location counter for (relocatable) expression position  // #659
+ *
  * @return true if valid absolute or relative expression, false otherwise
  */
-private boolean calc_exp(){
+private boolean calc_exp() { return calc_exp(0); }  // #659
+private boolean calc_exp(int loc_ctr_offset){       // #659
 	   if (exp_text == null || exp_index > exp_text.length()){
 	   	   exp_text = ""; // RPI 356
 		   return false;
@@ -7273,7 +7280,7 @@ private boolean calc_exp(){
 	   	   	  exp_token = "" + exp_term_op;
 	   	   	  exp_eot = true;
 	   	   }
-		   proc_exp_token();
+		   proc_exp_token(loc_ctr_offset); // #659
 	   }
 	   if (!bal_abort){
 		   if (!exp_eot){
@@ -7294,8 +7301,10 @@ private boolean calc_exp(){
  *  <li>exec or push operations + - * /</li>
  *  <li>terminate on end of string or ()</li>
  * </ol>
+ *
+ * @param loc_ctr_offset offset from location counter for (relocatable) expression position  // #659
  */
-private void proc_exp_token(){
+private void proc_exp_token(int loc_ctr_offset){ // #659
 	check_prev_op = true;
 	while (check_prev_op && !bal_abort){
 	    exp_op = exp_token.toUpperCase();
@@ -7305,24 +7314,24 @@ private void proc_exp_token(){
 	        		exp_token = "U+";
 	        		exp_op = exp_token;
 	        	}
-	        	proc_exp_op();
+	        	proc_exp_op(loc_ctr_offset); // #659
 	            break;
 	        case '-':
 	        	if (!exp_sym_pushed){
 	        		exp_token = "U-";
 	        		exp_op = exp_token;
 	        	}
-	        	proc_exp_op();
+	        	proc_exp_op(loc_ctr_offset); // #659
 	            break;
 	        case '*':
 	        	if  (exp_sym_last){
-	        	    proc_exp_op();
+	        	    proc_exp_op(loc_ctr_offset); // #659
 	        	} else {
 	        		proc_loc_ctr();
 	        	}
 	            break;
 	        case '/':
-	        	proc_exp_op();
+	        	proc_exp_op(loc_ctr_offset); // #659
 	            break;
 	        case '(':
 	        	if (exp_level == 0
@@ -7330,25 +7339,25 @@ private void proc_exp_token(){
 	        		&& tot_exp_stk_sym > 0){
 	        		exp_op = exp_term_op;
 	        	}
-	        	proc_exp_op();
+	        	proc_exp_op(loc_ctr_offset); // #659
 	            break;
 	        case ')':
-	        	proc_exp_op();
+	        	proc_exp_op(loc_ctr_offset); // #659
 	            break;
 	        case '\t': //tab  RPI181
 	        case '\r': //cr
 	        case '\n': //lf
 	        case ' ':  //space
 	        	exp_op = exp_term_op;
-	        	proc_exp_op();
+	        	proc_exp_op(loc_ctr_offset); // #659
 	            break;
 	        case ',':
 	        case '\'': // terminator for DCF, DCH, expressions
 	        	exp_op = exp_term_op;
-	        	proc_exp_op();
+	        	proc_exp_op(loc_ctr_offset); // #659
 	            break;
 	        case '~':  // terminator
-	        	proc_exp_op();
+	        	proc_exp_op(loc_ctr_offset); // #659
 	            break;
 	        case 'B':
 	        	if (exp_token.length() > 2 && exp_token.charAt(exp_token.length()-1) == '\''){ // RPI 270
@@ -7369,21 +7378,21 @@ private void proc_exp_token(){
 	            break;
 	        case 'I':  // RPI 790 I' operator
 	        	if (exp_token.length() > 1 && exp_token.charAt(1) == '\''){
-	        	   proc_exp_op();
+	        	   proc_exp_op(loc_ctr_offset); // #659
 	        	} else {
 	        	   proc_exp_sym();
 	        	}
 	            break;
 	        case 'L':
 	        	if (exp_token.length() > 1 && exp_token.charAt(1) == '\''){
-	        	   proc_exp_op();
+	        	   proc_exp_op(loc_ctr_offset); // #659
 	        	} else {
 	        	   proc_exp_sym();
 	        	}
 	            break;
 	        case 'S':  // RPI 790 S' operator
 	        	if (exp_token.length() > 1 && exp_token.charAt(1) == '\''){
-	        	   proc_exp_op();
+	        	   proc_exp_op(loc_ctr_offset); // #659
 	        	} else {
 	        	   proc_exp_sym();
 	        	}
@@ -7392,7 +7401,7 @@ private void proc_exp_token(){
 	        	if (exp_token.length() == 2
 	        		&& (exp_token.charAt(1) == '-'
 	        			|| exp_token.charAt(1) == '+')){
-		        	   proc_exp_op();
+		        	   proc_exp_op(loc_ctr_offset); // #659
 		        	} else {
 		        	   proc_exp_sym();
 		        	}
@@ -7473,8 +7482,10 @@ private void proc_exp_sdt(){
 
 /**
  * description missing
+ *
+ * @param loc_ctr_offset offset from location counter for (relocatable) expression position  // #659
  */
-private void proc_exp_op(){
+private void proc_exp_op(int loc_ctr_offset) { // #659
 	if  (tot_exp_stk_op > 0){
 	    exp_prev_op = exp_stk_op[tot_exp_stk_op -1];
 	} else {
@@ -7524,7 +7535,7 @@ private void proc_exp_op(){
   	   exp_level--;
   	   if (exp_level == 0 && bal_op.equals("AIF")){
   	   	  exp_op = exp_term_op;
-  	   	  exp_term();
+  	   	  exp_term(loc_ctr_offset); // #659
   	   }
   	   check_prev_op = false;
        break;
@@ -7561,12 +7572,12 @@ private void proc_exp_op(){
     	 }
          break;
     case 6: // terminator space, comma, unmatched )
-  	   exp_term();
+  	   exp_term(loc_ctr_offset); // #659
   	   check_prev_op = false;
   	   break;
   	case 7: // check if ( is terminator after value
   	   if (exp_sym_last){
-   	       exp_term();
+   	       exp_term(loc_ctr_offset); // #659
   	   } else {
    	       exp_push_op();
            exp_level++;
@@ -7843,8 +7854,10 @@ private void exp_pop_op(){
 /**
  * terminate expression returning
  * value on stack if no errors
+ *
+ * @param loc_ctr_offset offset from location counter for (relocatable) expression position  // #659
  */
-private void exp_term(){
+private void exp_term(int loc_ctr_offset){  // #659
 	if (tot_exp_stk_sym == 1 && tot_exp_stk_op == 0){
 		exp_term = true;
     	exp_val = exp_stk_sym_val[0];
@@ -7857,7 +7870,7 @@ private void exp_term(){
         } else if (exp_esd == esd_cpx_rld){
         	if (exp_rld_len > 0){ // RPI 893
         		if (gen_obj_code){
-        			gen_exp_rld();
+        			gen_exp_rld(loc_ctr_offset);  // #659
         		}    
             } else {
             	log_error(61,"invalid complex rld expression: " + exp_text.substring(0,exp_index)); // RPI 1034
@@ -7867,7 +7880,7 @@ private void exp_term(){
         		if (exp_rld_len > 0){ // RPI 894
         			exp_rld_add_esd[0] = exp_esd;
         			tot_exp_rld_add = 1;
-        			gen_exp_rld();
+        			gen_exp_rld(loc_ctr_offset);  // #659
         		}
         	}
             exp_type = sym_rel;
@@ -8707,8 +8720,11 @@ private String bytes_to_hex(byte[] bytes,int byte_start,int byte_length,int chun
  *  <li>Called from END processing with BAL_EOF to flush buffer.</li>
  *  <li>Reset obj_code for use by DC routines</li>
  * </ol>
+ *
+ * @param loc_ctr_offset offset from location counter for (relocatable) expression position  // #659
  */
-private void put_obj_text(){
+private void put_obj_text() { put_obj_text(0); }      // #659
+private void put_obj_text( int loc_ctr_offset ){      // #659
 	 if (tz390.z390_abort || mz390_abort){
 		 return;
 	 }
@@ -8732,7 +8748,7 @@ private void put_obj_text(){
 	 if (cur_text_len > 0
 	 	&& (bal_eof 
 	 		|| cur_text_esd != esd_base[cur_esd] // RPI 301
-		 	|| cur_text_loc != loc_ctr)){
+		 	|| cur_text_loc != loc_ctr_offset + loc_ctr)){  // #659
 		cur_text_loc = cur_text_loc - cur_text_len;
 		temp_obj_line = ".TXT ESD=" + tz390.get_hex(cur_text_esd,4) + " LOC=" + tz390.get_hex(cur_text_loc - sym_loc[esd_sid[cur_text_esd]],8) + " LEN=" + tz390.get_hex(cur_text_len,2) + " " + cur_text_buff;
 		put_obj_line(temp_obj_line);
@@ -8741,7 +8757,7 @@ private void put_obj_text(){
 	if (bal_eof || bal_abort)return;  // rpi 851
 	if (cur_text_len == 0){
 		cur_text_esd = esd_base[sym_esd[esd_sid[cur_esd]]]; // RPI 301
-		cur_text_loc = loc_ctr;
+		cur_text_loc = loc_ctr_offset + loc_ctr;  // #659
 		cur_text_buff = "";
 	} 
 	cur_text_buff = cur_text_buff.concat(obj_code);
@@ -12202,14 +12218,20 @@ private void gen_ccw0(){  // RPI 567
 		obj_code = obj_code + tz390.get_hex(exp_val,2);
 		loc_len  = 1;
 		put_obj_text();
-		loc_ctr++;
 		if (exp_text.charAt(exp_index) == ','){
 			 exp_index++;
 			 exp_rld_len = 3;
-			 if (calc_exp()){  // RPI 771
+			 // calc_exp() uses loc_ctr and loc_ctr offset for rld  // #659
+			 if (calc_exp(1)){  // RPI 771  #659
 				 obj_code = obj_code + tz390.get_hex(exp_val,6);
-				 put_obj_text();        // RPI 632 
-				 loc_ctr = loc_ctr + 3; // RPI 632
+				 // put object text at loc_ctr + 1  // #659
+				 put_obj_text(1);       // RPI 632  #659
+				 // Set loc_ctr past the command code and data address.  // #659
+				 // Per HLASM LR, the location counter does not change   // #659
+				 // for the entire generation of the CCW; however, it    // #659
+				 // is not referenced for the remaining fields, so       // #659
+				 // a problem does not arise here.                       // #659 
+				 loc_ctr = loc_ctr + 4; // RPI 632  #659
 				 if (exp_text.charAt(exp_index) == ','){
 					 exp_index++;
 					 exp_rld_len = 0;
@@ -12255,15 +12277,15 @@ private void gen_ccw1(){  // RPI 567
 		&& exp_val >= 0 
 		&& exp_val <  256){ 
 		ccw_op = tz390.get_hex(exp_val,2);
-		loc_ctr = loc_ctr + 4;
 		if (exp_text.charAt(exp_index) == ','){
 			 exp_index++;
 			 exp_rld_len = 4;
-			 if (calc_exp()){  // RPI 771
+			 // calc_exp() uses loc_ctr and loc_ctr offset for rld  // #659
+			 if (calc_exp(4)){  // RPI 771  #659
 				 obj_code = obj_code + tz390.get_hex(exp_val,8);
-				 put_obj_text();
+				 // put object text for the data address at loc_ctr + 4  // #659
+				 put_obj_text(4); // #659
 				 exp_rld_len = 0;
-				 loc_ctr = loc_ctr - 4;
 				 if (exp_text.charAt(exp_index) == ','){
 					 exp_index++;
 					 put_obj_text();

--- a/z390test/src/test/groovy/org/z390/test/RunAsmTests.groovy
+++ b/z390test/src/test/groovy/org/z390/test/RunAsmTests.groovy
@@ -97,6 +97,12 @@ class RunAsmTests extends z390Test {
         assert rc == 0
     }
     @Test
+    void test_IS659() {
+        int rc = this.asmlg(basePath("rt", "mlc", "IS659"), *options, 'optable(z390)')
+        this.printOutput()
+        assert rc == 0
+    }
+    @Test
     void test_TESTDC1() {
         int rc = this.asmlg(basePath("rt", "mlc", "TESTDC1"), *options, 'optable(z390)', "SYSOBJ(${basePath("linklib")})")
         this.printOutput()


### PR DESCRIPTION
The az390.java code incorrectly processes the code generation for CCW/CCW0/CCW1 due to updating the location counter value as it parses the CCW parameters. The HLASM LR states that the location counter remains constant when processing one statement.

The problem only manifests itself when a location counter reference is used for the data address, which is positioned at CCW/CCW0 offset 1, CCW1 offset 4. The az390.java code adds 1, respectively 4, before processing a data address value of the form "*-8", resulting in an incorrect value being generated.

The az390.java code has been updated to use a location counter offset value when generating relocatable expression values. The offset is 0 in most cases, maintaining existing processing for other than CCWs. The az390.java methods gen_ccw0() and gen_ccw1() have been modifed to use offsets of 1, respectively 4, when generating the data address values, leaving the location counter value unchanged.