### PR TITLE
Allow bash scripts for assemblies and COBOL compiles to have non-default input file extensions Is662

### DIFF
--- a/bash/asm
+++ b/bash/asm
@@ -30,13 +30,32 @@ if [ $trace -eq 1 ]; then set -x; fi
 
 if [ $# -eq 0 ] || [ -z "$1" ]; then echo "asm ERROR: missing file name"; exit 16; fi
 
-# remove trailing ".MLC", if any
-zFile="${1%.MLC}"
+# extract longest substring that ends with "/"
+dir=${0%/*}
 
-# error if missing name to left of ".MLC"
-if [ -z "$zFile" ]; then echo "asm ERROR: invalid file name $1"; exit 16; fi
-# error if input file with MLC extension does not exist
-if [ ! -f "$zFile".MLC ]; then echo "asm ERROR: file $zFile.MLC not found"; exit 16; fi
+# include the file containing the parsefilepath function
+source ${dir}/parsefilepath
+
+# input file path must not end with a period
+if [[ $1 == *. ]]; then echo "asm ERROR: file path ends with '.' - $1"; exit 16; fi
+
+# parse file path to get path, name, and extension; sets global variables z_fpath, z_fname, z_fext
+# Examples: if $1="demo/HELLO", returned values: z_fpath="demo/", z_fname="HELLO" z_fext=""
+#           if $1="demo/HELLO.MLC", returned values: z_fpath="demo/", z_fname="HELLO" z_fext="MLC"
+#           if $1="HELLO", returned values: z_fpath="", z_fname="HELLO" z_fext=""
+parsefilepath "$1"
+if [ $debug -eq 1 ]; then echo "after parsefilepath; \$z_fpath: >$z_fpath<  \$z_fname: >$z_fname<  \$z_fext: >$z_fext<"; fi
+
+# must have z_fname
+if [ -z "$z_fname" ]; then echo "asm ERROR: invalid/missing file name in file path- $1"; exit 16; fi
+# must not have a period in z_fname
+if [[ $z_fname == *.* ]]; then echo "asm ERROR: invalid character '.' in file name \"$z_fname\"; file path - $1"; exit 16; fi
+# if no z_fext, use default "MLC"
+if [ -z "$z_fext" ]; then z_fext="MLC"; fi
+zFile=${z_fpath}${z_fname}  # path, if any, followed by file name without extension
+# make sure file, with extension, exists
+if [ ! -f ${zFile}.${z_fext} ]; then echo "asm ERROR: file $zFile.$z_fext not found"; exit 16; fi
+if [ $debug -eq 1 ]; then echo "full file name with path and extension: >${zFile}.${z_fext}<"; fi
 
 # remove previously created files, if any
 if [ -f "$zFile.BAL" ]; then rm $zFile.BAL; fi
@@ -50,9 +69,6 @@ if [ -f "$zFile.STA" ]; then rm $zFile.STA; fi
 #if [ -f $zFile.TR* ]; then rm $zFile.TR*; fi
 if ls $zFile.TR* 1>/dev/null 2>&1; then rm -f $zFile.TR*; fi
 
-# extract longest substring that ends with "/"
-dir=${0%/*}
-
 # get the z390 directory
 zdir=$(dirname $0)
 zdir=$(cd $zdir && pwd)
@@ -61,7 +77,8 @@ zdir=$(dirname $zdir)
 sysmac='sysmac(+'$zdir'/mac)'
 syscpy='syscpy(+'$zdir'/mac)'
 
-${dir}/mz390 $zFile $sysmac $syscpy $2 $3 $4 $5 $6 $7 $8 $9
+# invoke macro processor
+${dir}/mz390 $zFile.$z_fext $sysmac $syscpy $2 $3 $4 $5 $6 $7 $8 $9
 rc=$?
 if [ $debug -eq 1 ]; then echo "asm: mz390 rc=$rc"; fi
 if [ $rc -ne 0 ]; then

--- a/bash/asml
+++ b/bash/asml
@@ -30,13 +30,32 @@ if [ $trace -eq 1 ]; then set -x; fi
 
 if [ $# -eq 0 ] || [ -z "$1" ]; then echo "asml ERROR: missing file name"; exit 16; fi
 
-# remove trailing ".MLC", if any
-zFile="${1%.MLC}"
+# extract longest substring that ends with "/"
+dir=${0%/*}
 
-# error if missing name to left of ".MLC"
-if [ -z "$zFile" ]; then echo "asml ERROR: invalid file name $1"; exit 16; fi
-# error if input file with MLC extension does not exist
-if [ ! -f "$zFile".MLC ]; then echo "asml ERROR: file $zFile.MLC not found"; exit 16; fi
+# include the file containing the parsefilepath function
+source ${dir}/parsefilepath
+
+# input file path must not end with a period
+if [[ $1 == *. ]]; then echo "asml ERROR: file path ends with '.' - $1"; exit 16; fi
+
+# parse file path to get path, name, and extension; sets global variables z_fpath, z_fname, z_fext
+# Examples: if $1="demo/HELLO", returned values: z_fpath="demo/", z_fname="HELLO" z_fext=""
+#           if $1="demo/HELLO.MLC", returned values: z_fpath="demo/", z_fname="HELLO" z_fext="MLC"
+#           if $1="HELLO", returned values: z_fpath="", z_fname="HELLO" z_fext=""
+parsefilepath "$1"
+if [ $debug -eq 1 ]; then echo "after parsefilepath; \$z_fpath: >$z_fpath<  \$z_fname: >$z_fname<  \$z_fext: >$z_fext<"; fi
+
+# must have z_fname
+if [ -z "$z_fname" ]; then echo "asml ERROR: invalid/missing file name in file path- $1"; exit 16; fi
+# must not have a period in z_fname
+if [[ $z_fname == *.* ]]; then echo "asml ERROR: invalid character '.' in file name \"$z_fname\"; file path - $1"; exit 16; fi
+# if no z_fext, use default "MLC"
+if [ -z "$z_fext" ]; then z_fext="MLC"; fi
+zFile=${z_fpath}${z_fname}  # path, if any, followed by file name without extension
+# make sure file, with extension, exists
+if [ ! -f ${zFile}.${z_fext} ]; then echo "asml ERROR: file $zFile.$z_fext not found"; exit 16; fi
+if [ $debug -eq 1 ]; then echo "full file name with path and extension: >${zFile}.${z_fext}<"; fi
 
 # remove previously created files, if any
 if [ -f "$zFile.BAL" ]; then rm $zFile.BAL; fi
@@ -51,9 +70,6 @@ if [ -f "$zFile.STA" ]; then rm $zFile.STA; fi
 # .TR* file(s) exist if "ls" exit status is 0
 if ls $zFile.TR* 1>/dev/null 2>&1; then rm -f $zFile.TR*; fi
 
-# extract longest substring that ends with "/"
-dir=${0%/*}
-
 # get the z390 directory
 zdir=$(dirname $0)
 zdir=$(cd $zdir && pwd)
@@ -62,18 +78,18 @@ zdir=$(dirname $zdir)
 sysmac='sysmac(+'$zdir'/mac)'
 syscpy='syscpy(+'$zdir'/mac)'
 
-${dir}/mz390 $zFile $sysmac $syscpy $2 $3 $4 $5 $6 $7 $8 $9
+# invoke macro processor
+${dir}/mz390 $zFile.$z_fext $sysmac $syscpy $2 $3 $4 $5 $6 $7 $8 $9
 rc=$?
 if [ $debug -eq 1 ]; then echo "asml: mz390 rc=$rc"; fi
-
 if [ $rc -eq 0 ] || [ $rc -eq 4 ]; then
     if [ $rc -eq 4 ]; then
         echo "asml WARNING: mz390 rc=$rc; see warnings in mz390 generated $zFile.BAL/ERR/PRN file(s) and on console"    
     fi 
-    ${dir}/lz390 $1 $2 $3 $4 $5 $6 $7 $8 $9
+    # invoke linker
+    ${dir}/lz390 $zFile $2 $3 $4 $5 $6 $7 $8 $9
     rc=$?
     if [ $debug -eq 1 ]; then echo "asml: lz390 rc=$rc"; fi
-    
     if [ $rc -ne 0 ]; then
         if [ $rc -eq 4 ]; then
                 echo "asml WARNING: lz390 rc=$rc; see warnings in lz390 generated $zFile.LST file  and on console"

--- a/bash/asmlg
+++ b/bash/asmlg
@@ -30,13 +30,32 @@ if [ $trace -eq 1 ]; then set -x; fi
 
 if [ $# -eq 0 ] || [ -z "$1" ]; then echo "asmlg ERROR: missing file name"; exit 16; fi
 
-# remove trailing ".MLC", if any
-zFile="${1%.MLC}"
+# extract longest substring that ends with "/"
+dir=${0%/*}
 
-# error if missing name to left of ".MLC"
-if [ -z "$zFile" ]; then echo "asmlg ERROR: invalid file name $1"; exit 16; fi
-# error if input file with MLC extension does not exist
-if [ ! -f "$zFile".MLC ]; then echo "asmlg ERROR: file $zFile.MLC not found"; exit 16; fi
+# include the file containing the parsefilepath function
+source ${dir}/parsefilepath
+
+# input file path must not end with a period
+if [[ $1 == *. ]]; then echo "asmlg ERROR: file path ends with '.' - $1"; exit 16; fi
+
+# parse file path to get path, name, and extension; sets global variables z_fpath, z_fname, z_fext
+# Examples: if $1="demo/HELLO", returned values: z_fpath="demo/", z_fname="HELLO" z_fext=""
+#           if $1="demo/HELLO.MLC", returned values: z_fpath="demo/", z_fname="HELLO" z_fext="MLC"
+#           if $1="HELLO", returned values: z_fpath="", z_fname="HELLO" z_fext=""
+parsefilepath "$1"
+if [ $debug -eq 1 ]; then echo "after parsefilepath; \$z_fpath: >$z_fpath<  \$z_fname: >$z_fname<  \$z_fext: >$z_fext<"; fi
+
+# must have z_fname
+if [ -z "$z_fname" ]; then echo "asmlg ERROR: invalid/missing file name in file path- $1"; exit 16; fi
+# must not have a period in z_fname
+if [[ $z_fname == *.* ]]; then echo "asmlg ERROR: invalid character '.' in file name \"$z_fname\"; file path - $1"; exit 16; fi
+# if no z_fext, use default "MLC"
+if [ -z "$z_fext" ]; then z_fext="MLC"; fi
+zFile=${z_fpath}${z_fname}  # path, if any, followed by file name without extension
+# make sure file, with extension, exists
+if [ ! -f ${zFile}.${z_fext} ]; then echo "asmlg ERROR: file $zFile.$z_fext not found"; exit 16; fi
+if [ $debug -eq 1 ]; then echo "full file name with path and extension: >${zFile}.${z_fext}<"; fi
 
 # remove previously created files, if any
 if [ -f "$zFile.BAL" ]; then rm $zFile.BAL; fi
@@ -51,9 +70,6 @@ if [ -f "$zFile.STA" ]; then rm $zFile.STA; fi
 # .TR* file(s) exist if "ls" exit status is 0
 if ls $zFile.TR* 1>/dev/null 2>&1; then rm -f $zFile.TR*; fi
 
-# extract longest substring that ends with "/"
-dir=${0%/*}
-
 # get the z390 directory
 zdir=$(dirname $0)
 zdir=$(cd $zdir && pwd)
@@ -62,14 +78,16 @@ zdir=$(dirname $zdir)
 sysmac='sysmac(+'$zdir'/mac)'
 syscpy='syscpy(+'$zdir'/mac)'
 
-${dir}/mz390 $zFile $sysmac $syscpy $2 $3 $4 $5 $6 $7 $8 $9
+# invoke macro processor
+${dir}/mz390 $zFile.$z_fext $sysmac $syscpy $2 $3 $4 $5 $6 $7 $8 $9
 rc=$?
 if [ $debug -eq 1 ]; then echo "asmlg: mz390 rc=$rc"; fi
 
 if [ $rc -eq 0 ] || [ $rc -eq 4 ]; then
     if [ $rc -eq 4 ]; then
         echo "asmlg WARNING: mz390 rc=$rc; see warnings in mz390 generated $zFile.BAL/ERR/PRN file(s) and on console"    
-    fi 
+    fi
+    # invoke linker
     ${dir}/lz390 $zFile $2 $3 $4 $5 $6 $7 $8 $9
     rc=$?
     if [ $debug -eq 1 ]; then echo "asmlg: lz390 rc=$rc"; fi
@@ -78,7 +96,7 @@ if [ $rc -eq 0 ] || [ $rc -eq 4 ]; then
         if [ $rc -eq 4 ]; then
             echo "asmlg WARNING: lz390 rc=$rc; see warnings in lz390 generated $zFile.LST file and on console"    
         fi 
-
+        # invoke executor/emulator
         ${dir}/ez390 $zFile $2 $3 $4 $5 $6 $7 $8 $9
         rc=$?
         if [ $debug -eq 1 ]; then echo "asmlg: ez390 rc=$rc"; fi

--- a/bash/assist
+++ b/bash/assist
@@ -1,28 +1,47 @@
 #!/bin/bash
 
-# assist: assemble, link, and exec ASSIST program $1.MLC 
+# assist: assemble, link, and exec ASSIST program $1.MLC
+
+# debug flag; 0=no debug, 1=debug
+debug=0
 
 if [ $# -eq 0 ] || [ -z "$1" ]; then echo "assist ERROR: missing file name"; exit 12; fi
-
-# remove trailing ".MLC", if any
-zFile="${1%.MLC}"
-
-# error if missing name to left of ".MLC"
-if [ -z "$zFile" ]; then echo "assist ERROR: invalid file name $1"; exit 16; fi
-# error if input file with MLC extension does not exist
-if [ ! -f "$zFile".MLC ]; then echo "assist ERROR: file $zFile.MLC not found"; exit 16; fi
 
 # extract longest substring that ends with "/"
 dir=${0%/*}
 
-export XREAD=$1.XRD
-export XPRNT=$1.XPR
-export XPNCH=$1.XPH
-export XGET=$1.XGT
-export XPUT=$1.XPT
+# include the file containing the parsefilepath function
+source ${dir}/parsefilepath
 
-${dir}/asmlg $zFile ASSIST $2 $3 $4 $5 $6 $7 $8 $9
+# input file path must not end with a period
+if [[ $1 == *. ]]; then echo "assist ERROR: file path ends with '.' - $1"; exit 16; fi
+
+# parse file path to get path, name, and extension; sets global variables z_fpath, z_fname, z_fext
+# Examples: if $1="assist/demo/DEMOAST1", returned values: z_fpath="assist/demo/", z_fname="DEMOAST1" z_fext=""
+#           if $1="assist/demo/DEMOAST1.MLC", returned values: z_fpath="assist/demo/", z_fname="DEMOAST1" z_fext="MLC"
+parsefilepath "$1"
+if [ $debug -eq 1 ]; then echo "after parsefilepath; \$z_fpath: >$z_fpath<  \$z_fname: >$z_fname<  \$z_fext: >$z_fext<"; fi
+
+# must have z_fname
+if [ -z "$z_fname" ]; then echo "assist ERROR: invalid/missing file name in file path- $1"; exit 16; fi
+# must not have a period in z_fname
+if [[ $z_fname == *.* ]]; then echo "assist ERROR: invalid character '.' in file name \"$z_fname\"; file path - $1"; exit 16; fi
+# if no z_fext, use default "MLC"
+if [ -z "$z_fext" ]; then z_fext="MLC"; fi
+zFile=${z_fpath}${z_fname}  # path, if any, followed by file name without extension
+# make sure file, with extension, exists
+if [ ! -f ${zFile}.${z_fext} ]; then echo "assist ERROR: file $zFile.$z_fext not found"; exit 16; fi
+if [ $debug -eq 1 ]; then echo "full file name with path and extension: >${zFile}.${z_fext}<"; fi
+
+export XREAD=$zFile.XRD
+export XPRNT=$zFile.XPR
+export XPNCH=$zFile.XPH
+export XGET=$zFile.XGT
+export XPUT=$zFile.XPT
+
+# assemble, link, and go with ASSIST option
+${dir}/asmlg $zFile.$z_fext ASSIST $2 $3 $4 $5 $6 $7 $8 $9
 rc=$?
-# error or warning messages issued by asmlg
+# error or warning messages may be issued by asmlg
 
 exit $rc

--- a/bash/cblc
+++ b/bash/cblc
@@ -30,13 +30,31 @@ if [ $trace -eq 1 ]; then set -x; fi
 
 if [ $# -eq 0 ] || [ -z "$1" ]; then echo "cblc ERROR: missing file name"; exit 16; fi
 
-# remove trailing ".CBL", if any
-zFile="${1%.CBL}"
+# extract longest substring that ends with "/"
+dir=${0%/*}
 
-# error if missing name to left of ".CBL"
-if [ -z "$zFile" ]; then echo "cblc ERROR: invalid file name $1"; exit 16; fi
-# error if input file with CBL extension does not exist
-if [ ! -f "$zFile".CBL ]; then echo "cblc ERROR: file $zFile.CBL not found"; exit 16; fi
+# include the file containing the parsefilepath function
+source ${dir}/parsefilepath
+
+# input file path must not end with a period
+if [[ $1 == *. ]]; then echo "cblc ERROR: file path ends with '.' - $1"; exit 16; fi
+
+# parse file path to get path, name, and extension; sets global variables z_fpath, z_fname, z_fext
+# Examples: if $1="zcobol/demo/HELLO", returned values: z_fpath="zcobol/demo/", z_fname="HELLO" z_fext=""
+#           if $1="zcobol/demo/HELLO.CBL", returned values: z_fpath="zcobol/demo/", z_fname="HELLO" z_fext="CBL"
+parsefilepath "$1"
+if [ $debug -eq 1 ]; then echo "after parsefilepath; \$z_fpath: >$z_fpath<  \$z_fname: >$z_fname<  \$z_fext: >$z_fext<"; fi
+
+# must have z_fname
+if [ -z "$z_fname" ]; then echo "cblc ERROR: invalid/missing file name in file path- $1"; exit 16; fi
+# must not have a period in z_fname
+if [[ $z_fname == *.* ]]; then echo "cblc ERROR: invalid character '.' in file name \"$z_fname\"; file path - $1"; exit 16; fi
+# if no z_fext, use default "CBL"
+if [ -z "$z_fext" ]; then z_fext="CBL"; fi
+zFile=${z_fpath}${z_fname}  # path, if any, followed by file name without extension
+# make sure file, with extension, exists
+if [ ! -f ${zFile}.${z_fext} ]; then echo "cblc ERROR: file $zFile.$z_fext not found"; exit 16; fi
+if [ $debug -eq 1 ]; then echo "full file name with path and extension: >${zFile}.${z_fext}<"; fi
 
 # remove previously created files, if any
 if [ -f "$zFile.MLC" ]; then rm $zFile.MLC; fi
@@ -52,15 +70,13 @@ if [ -f "$zFile.java" ]; then rm $zFile.java; fi
 if [ -f "$zFile.class" ]; then rm $zFile.class; fi
 if [ -f "$zFile_ZC_LABELS.CPY" ]; then rm $zFile._ZC_LABELS.CPY; fi
 
-# extract longest substring that ends with "/"
-dir=${0%/*}
-
 # get the z390 directory
 zdir=$(dirname $0)
 zdir=$(cd $zdir && pwd)
 zdir=$(dirname $zdir)
 
-${dir}/zc390 $zFile $2 $3 $4 $5 $6 $7 $8 $9
+# invoke COBOL preprocessor: convert COBOL source to assembler source (MLC extension)
+${dir}/zc390 $zFile.$z_fext $2 $3 $4 $5 $6 $7 $8 $9
 rc=$?
 if [ $debug -eq 1 ]; then echo "cblc: zc390 rc=$rc"; fi
 if [ $rc -eq 0 ] || [ $rc -eq 4 ]; then
@@ -71,6 +87,7 @@ if [ $rc -eq 0 ] || [ $rc -eq 4 ]; then
     sysmac='sysmac('$zdir'/zcobol/mac+'$zdir'/mac)'
     syscpy='syscpy(+'$zdir'/zcobol/cpy)'
     if [ $debug -eq 1 ]; then echo "cblc: cblopt=$cblopt"; fi
+    # invoke macro processor with input the generated assembler source
     ${dir}/mz390 $zFile $cblopt $sysmac $syscpy $2 $3 $4 $5 $6 $7 $8 $9
     rc=$?
     if [ $debug -eq 1 ]; then echo "cblc: mz390 rc=$rc"; fi

--- a/bash/cblcl
+++ b/bash/cblcl
@@ -30,13 +30,31 @@ if [ $trace -eq 1 ]; then set -x; fi
 
 if [ $# -eq 0 ] || [ -z "$1" ]; then echo "cblcl ERROR: missing file name"; exit 16; fi
 
-# remove trailing ".CBL", if any
-zFile="${1%.CBL}"
+# extract longest substring that ends with "/"
+dir=${0%/*}
 
-# error if missing name to left of ".CBL"
-if [ -z "$zFile" ]; then echo "cblcl ERROR: invalid file name $1"; exit 16; fi
-# error if input file with CBL extension does not exist
-if [ ! -f "$zFile".CBL ]; then echo "cblcl ERROR: file $zFile.CBL not found"; exit 16; fi
+# include the file containing the parsefilepath function
+source ${dir}/parsefilepath
+
+# input file path must not end with a period
+if [[ $1 == *. ]]; then echo "cblcl ERROR: file path ends with '.' - $1"; exit 16; fi
+
+# parse file path to get path, name, and extension; sets global variables z_fpath, z_fname, z_fext
+# Examples: if $1="zcobol/demo/HELLO", returned values: z_fpath="zcobol/demo/", z_fname="HELLO" z_fext=""
+#           if $1="zcobol/demo/HELLO.CBL", returned values: z_fpath="zcobol/demo/", z_fname="HELLO" z_fext="CBL"
+parsefilepath "$1"
+if [ $debug -eq 1 ]; then echo "after parsefilepath; \$z_fpath: >$z_fpath<  \$z_fname: >$z_fname<  \$z_fext: >$z_fext<"; fi
+
+# must have z_fname
+if [ -z "$z_fname" ]; then echo "cblcl ERROR: invalid/missing file name in file path- $1"; exit 16; fi
+# must not have a period in z_fname
+if [[ $z_fname == *.* ]]; then echo "cblcl ERROR: invalid character '.' in file name \"$z_fname\"; file path - $1"; exit 16; fi
+# if no z_fext, use default "CBL"
+if [ -z "$z_fext" ]; then z_fext="CBL"; fi
+zFile=${z_fpath}${z_fname}  # path, if any, followed by file name without extension
+# make sure file, with extension, exists
+if [ ! -f ${zFile}.${z_fext} ]; then echo "cblcl ERROR: file $zFile.$z_fext not found"; exit 16; fi
+if [ $debug -eq 1 ]; then echo "full file name with path and extension: >${zFile}.${z_fext}<"; fi
 
 # remove previously created files, if any
 if [ -f "$zFile.MLC" ]; then rm $zFile.MLC; fi
@@ -52,15 +70,13 @@ if [ -f "$zFile.java" ]; then rm $zFile.java; fi
 if [ -f "$zFile.class" ]; then rm $zFile.class; fi
 if [ -f "$zFile_ZC_LABELS.CPY" ]; then rm $zFile._ZC_LABELS.CPY; fi
 
-# extract longest substring that ends with "/"
-dir=${0%/*}
-
 # get the z390 directory
 zdir=$(dirname $0)
 zdir=$(cd $zdir && pwd)
 zdir=$(dirname $zdir)
 
-${dir}/zc390 $zFile $2 $3 $4 $5 $6 $7 $8 $9
+# invoke COBOL preprocessor: convert COBOL source to assembler source (MLC extension)
+${dir}/zc390 $zFile.$z_fext $2 $3 $4 $5 $6 $7 $8 $9
 rc=$?
 if [ $debug -eq 1 ]; then echo "cblcl: zc390 rc=$rc"; fi
 
@@ -72,6 +88,7 @@ if [ $rc -eq 0 ] || [ $rc -eq 4 ]; then
     sysmac='sysmac('$zdir'/zcobol/mac+'$zdir'/mac)'
     syscpy='syscpy(+'$zdir'/zcobol/cpy)'
     if [ $debug -eq 1 ]; then echo "cblcl: cblopt=$cblopt"; fi
+    # invoke macro processor with input the generated assembler source
     ${dir}/mz390 $zFile $cblopt $sysmac $syscpy $2 $3 $4 $5 $6 $7 $8 $9
     rc=$?
     if [ $debug -eq 1 ]; then echo "cblcl: mz390 rc=$rc"; fi
@@ -79,7 +96,8 @@ if [ $rc -eq 0 ] || [ $rc -eq 4 ]; then
     if [ $rc -eq 0 ] || [ $rc -eq 4 ]; then
         if [ $rc -eq 4 ]; then
             echo "cblcl WARNING: mz390 rc=$rc; see warnings in mz390 generated $zFile.BAL/ERR/PRN file(s) and on console"    
-        fi 
+        fi
+        # invoke linker
         ${dir}/lz390 $zFile $2 $3 $4 $5 $6 $7 $8 $9
         rc=$?
         if [ $debug -eq 1 ]; then echo "cblcl: lz390 rc=$rc"; fi

--- a/bash/cblclg
+++ b/bash/cblclg
@@ -30,13 +30,31 @@ if [ $trace -eq 1 ]; then set -x; fi
 
 if [ $# -eq 0 ] || [ -z "$1" ]; then echo "cblclg ERROR: missing file name"; exit 16; fi
 
-# remove trailing ".CBL", if any
-zFile="${1%.CBL}"
+# extract longest substring that ends with "/"
+dir=${0%/*}
 
-# error if missing name to left of ".CBL"
-if [ -z "$zFile" ]; then echo "cblclg ERROR: invalid file name $1"; exit 16; fi
-# error if input file with CBL extension does not exist
-if [ ! -f "$zFile".CBL ]; then echo "cblclg ERROR: file $zFile.CBL not found"; exit 16; fi
+# include the file containing the parsefilepath function
+source ${dir}/parsefilepath
+
+# input file path must not end with a period
+if [[ $1 == *. ]]; then echo "cblclg ERROR: file path ends with '.' - $1"; exit 16; fi
+
+# parse file path to get path, name, and extension; sets global variables z_fpath, z_fname, z_fext
+# Examples: if $1="zcobol/demo/HELLO", returned values: z_fpath="zcobol/demo/", z_fname="HELLO" z_fext=""
+#           if $1="zcobol/demo/HELLO.CBL", returned values: z_fpath="zcobol/demo/", z_fname="HELLO" z_fext="CBL"
+parsefilepath "$1"
+if [ $debug -eq 1 ]; then echo "after parsefilepath; \$z_fpath: >$z_fpath<  \$z_fname: >$z_fname<  \$z_fext: >$z_fext<"; fi
+
+# must have z_fname
+if [ -z "$z_fname" ]; then echo "cblclg ERROR: invalid/missing file name in file path- $1"; exit 16; fi
+# must not have a period in z_fname
+if [[ $z_fname == *.* ]]; then echo "cblclg ERROR: invalid character '.' in file name \"$z_fname\"; file path - $1"; exit 16; fi
+# if no z_fext, use default "CBL"
+if [ -z "$z_fext" ]; then z_fext="CBL"; fi
+zFile=${z_fpath}${z_fname}  # path, if any, followed by file name without extension
+# make sure file, with extension, exists
+if [ ! -f ${zFile}.${z_fext} ]; then echo "cblclg ERROR: file $zFile.$z_fext not found"; exit 16; fi
+if [ $debug -eq 1 ]; then echo "full file name with path and extension: >${zFile}.${z_fext}<"; fi
 
 # remove previously created files, if any
 if [ -f "$zFile.MLC" ]; then rm $zFile.MLC; fi
@@ -52,15 +70,13 @@ if [ -f "$zFile.java" ]; then rm $zFile.java; fi
 if [ -f "$zFile.class" ]; then rm $zFile.class; fi
 if [ -f "$zFile_ZC_LABELS.CPY" ]; then rm $zFile._ZC_LABELS.CPY; fi
 
-# extract longest substring that ends with "/"
-dir=${0%/*}
-
 # get the z390 directory
 zdir=$(dirname $0)
 zdir=$(cd $zdir && pwd)
 zdir=$(dirname $zdir)
 
-${dir}/zc390 $zFile $2 $3 $4 $5 $6 $7 $8 $9
+# invoke COBOL preprocessor: convert COBOL source to assembler source (MLC extension)
+${dir}/zc390 $zFile.$z_fext $2 $3 $4 $5 $6 $7 $8 $9
 rc=$?
 if [ $debug -eq 1 ]; then echo "cblclg: zc390 rc=$rc"; fi
 if [ $rc -eq 0 ] || [ $rc -eq 4 ]; then
@@ -71,10 +87,12 @@ if [ $rc -eq 0 ] || [ $rc -eq 4 ]; then
     sysmac='sysmac('$zdir'/zcobol/mac+'$zdir'/mac)'
     syscpy='syscpy(+'$zdir'/zcobol/cpy)'
     if [ $debug -eq 1 ]; then echo "cblcl: cblopt=$cblopt"; fi
+    # invoke macro processor with input the generated assembler source
     ${dir}/mz390 $zFile $cblopt $sysmac $syscpy $2 $3 $4 $5 $6 $7 $8 $9
     rc=$?
     if [ $debug -eq 1 ]; then echo "cblcl: mz390 rc=$rc"; fi
     if [ $rc -eq 0 ]; then
+        # invoke linker
         ${dir}/lz390 $zFile $2 $3 $4 $5 $6 $7 $8 $9
         rc=$?
         if [ $debug -eq 1 ]; then echo "cblclg: lz390 rc=$rc"; fi
@@ -82,9 +100,10 @@ if [ $rc -eq 0 ] || [ $rc -eq 4 ]; then
         if [ $rc -eq 0 ] || [ $rc -eq 4 ]; then
             if [ $rc -eq 4 ]; then
                 echo "cblclg WARNING: lz390 rc=$rc; see warnings in lz390 generated $zFile.LST file and on console"    
-            fi 
+            fi
         
             sys390='sys390(+'$zdir'/zcobol/lib)'
+            # invoke executor/emulator
             ${dir}/ez390 $zFile $sys390 $2 $3 $4 $5 $6 $7 $8 $9
             rc=$?
             if [ $debug -eq 1 ]; then echo "cblclg: ez390 rc=$rc"; fi

--- a/bash/mac
+++ b/bash/mac
@@ -30,13 +30,32 @@ if [ $trace -eq 1 ]; then set -x; fi
 
 if [ $# -eq 0 ] || [ -z "$1" ]; then echo "mac ERROR: missing file name"; exit 16; fi
 
-# remove trailing ".MLC", if any
-zFile="${1%.MLC}"
+# extract longest substring that ends with "/"
+dir=${0%/*}
 
-# error if missing name to left of ".MLC"
-if [ -z "$zFile" ]; then echo "mac ERROR: invalid file name $1"; exit 16; fi
-# error if input file with MLC extension does not exist
-if [ ! -f "$zFile".MLC ]; then echo "mac ERROR: file $zFile.MLC not found"; exit 16; fi
+# include the file containing the parsefilepath function
+source ${dir}/parsefilepath
+
+# input file path must not end with a period
+if [[ $1 == *. ]]; then echo "mac ERROR: file path ends with '.' - $1"; exit 16; fi
+
+# parse file path to get path, name, and extension; sets global variables z_fpath, z_fname, z_fext
+# Examples: if $1="demo/HELLO", returned values: z_fpath="demo/", z_fname="HELLO" z_fext=""
+#           if $1="demo/HELLO.MLC", returned values: z_fpath="demo/", z_fname="HELLO" z_fext="MLC"
+#           if $1="HELLO", returned values: z_fpath="", z_fname="HELLO" z_fext=""
+parsefilepath "$1"
+if [ $debug -eq 1 ]; then echo "after parsefilepath; \$z_fpath: >$z_fpath<  \$z_fname: >$z_fname<  \$z_fext: >$z_fext<"; fi
+
+# must have z_fname
+if [ -z "$z_fname" ]; then echo "mac ERROR: invalid/missing file name in file path - $1"; exit 16; fi
+# must not have a period in z_fname
+if [[ $z_fname == *.* ]]; then echo "mac ERROR: invalid character '.' in file name \"$z_fname\"; file path - $1"; exit 16; fi
+# if no z_fext, use default "MLC"
+if [ -z "$z_fext" ]; then z_fext="MLC"; fi
+zFile=${z_fpath}${z_fname}  # path, if any, followed by file name without extension
+# make sure file, with extension, exists
+if [ ! -f ${zFile}.${z_fext} ]; then echo "mac ERROR: file $zFile.$z_fext not found"; exit 16; fi
+if [ $debug -eq 1 ]; then echo "full file name with path and extension: >${zFile}.${z_fext}<"; fi
 
 # remove previously created files, if any
 if [ -f "$zFile.BAL" ]; then rm $zFile.BAL; fi
@@ -45,20 +64,10 @@ if [ -f "$zFile.STA" ]; then rm $zFile.STA; fi
 #if [ -f $zFile.TR* ]; then rm $zFile.TR*; fi
 if ls $zFile.TR* 1>/dev/null 2>&1; then rm -f $zFile.TR*; fi
 
-# extract longest substring that ends with "/"
-dir=${0%/*}
-
 # get the z390 directory
 zdir=$(dirname $0)
 zdir=$(cd $zdir && pwd)
 zdir=$(dirname $zdir)
-
-if [ $debug -eq 1 ]; then
-    echo "mac 1=$1"
-    echo "mac 2=$2"
-    echo "mac 3=$3"
-    echo "mac 4=$4"
-fi
 
 sysmac='sysmac('$zdir'/mac+.)'
 syscpy='syscpy('$zdir'/mac+.)'
@@ -68,11 +77,10 @@ chkmac='chkmac(0)'
 if [ $debug -eq 1 ]; then
     echo "mac sysmac=$sysmac"
     echo "mac syscpy=$syscpy"
-    echo "mac chksrc=$chksrc"
-    echo "mac chkmac=$chkmac"
 fi
 
-${dir}/mz390 $zFile bal noasm $sysmac $syscpy $chksrc $chkmac $2 $3 $4 $5 $6 $7 $8 $9
+# invoke macro processor
+${dir}/mz390 $zFile.$z_fext bal noasm $sysmac $syscpy $chksrc $chkmac $2 $3 $4 $5 $6 $7 $8 $9
 rc=$?
 if [ $debug -eq 1 ]; then echo "mac: mz390 rc=$rc"; fi
 if [ $rc -ne 0 ]; then

--- a/bash/parsefilepath
+++ b/bash/parsefilepath
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# parsefilepath: a function to extract filepath, filename, fileextension from input string
+#     input: string containing file path in format [<path-to-file>]<file-name>[.<file-extension>]
+#     output: sets global variables z_fpath, z_fname, z_fext
+#
+#     usage: The bash script that invokes the function must source this file prior to
+#            invoking the parsefilepath function with argument:
+#                "[<path-to-file>]<file-name>[.<file-extension]".
+#            For example, in the invoking bash script
+#                # include the parsefilepath function
+#                source <path-to-parsefilepath>/parsefilepath
+#                ...
+#                set filename to string [<path-to-file>]<file-name>[.<file-extension>]"
+#                # See examples below
+#                parsefilepath "$filename"
+#                # The function sets the following global variables:
+#                #    z_fpath contains path to the file (empty string if omitted)
+#                #    z_fname contains the file name (empty string if omitted)
+#                #    z_fext contains the file extension (empty string if omitted)
+#
+#            Note that a non-empty z_fpath ends with "/" and z_fext does not include
+#            the "." separating name and extension.
+#
+#            Examples.
+#
+#                Input         Output      Output     Output
+#                file path     z_fpath     z_fname    z_fext
+#                ----------    --------    -------    ------
+#                /a/b.c/d.e    /a/b.c/     d          e
+#                /a/b.c/d      /a/b.c/     d          ""
+#             *  /a/b.c/d.     /a/b.c/     d          ""
+#             *  /a/b.c/.e     /a/b.c/     ""         e
+#             *  /a/b.c/       /a/b.c/     ""         ""
+#                a/b.c/d.e     a/b.c/      d          e
+#                d.e           ""          d          e
+#                d             ""          d          ""
+#             *  d.            ""          d          ""
+#             *  .e            ""          ""         e
+#             *  ""            ""          ""         ""
+#
+# Notes: 1. The input string is only parsed. The returned values are not validated
+#           for a valid file name.
+#        2. The examples above with "*" on the left are actually invalid/improper z390
+#           file names and must be handled accordingly by the invoking bash script.
+#           See z390 bash/asm for sample code.
+#
+
+function parsefilepath() {
+
+    local str
+    local end
+
+    str=$1  # copy file path
+    
+    # extract what follows the last "/" in str; equals "filename[.fileextension]"; may be empty
+    end=${str##*/}
+
+    # set z_fpath; from beginning of string through ending "/"; may be empty
+    z_fpath="${str:0:$((${#str} - ${#end}))}"
+
+    # get file name = "filename[.fileextension]"
+    str=$end
+
+    # extract what follows the last "." in str; equals "fileextension"; may be empty
+    end=${str##*.}
+
+    # set z_fname and z_fext
+    if [ "$str" = "$end" ]; then                      # no "." in str (file name) so no extension
+        z_fname=$str
+        z_fext=""
+    else
+        z_fname="${str:0:$((${#str} - ${#end} - 1))}" # 0 up to but not including the "."
+        z_fext=$end
+    fi
+}

--- a/bash/runcbldemos
+++ b/bash/runcbldemos
@@ -10,7 +10,7 @@ demopath=zcobol/demo
 # validate compilation with explicit extension default/non-default
 bash/cblclg ${demopath}/HELLO.CBL $1 $2 $3 $4 $5 $6 $7 $8 $9
 echo "Verify Hello World"
-bash/cblclg ${demopath}/HELLO.Cobol $1 $2 $3 $4 $5 $6 $7 $8 $9
+bash/cblclg ${demopath}/HELLO2.Cobol $1 $2 $3 $4 $5 $6 $7 $8 $9
 echo "Verify Hello Again World"
 
 bash/cblclg ${demopath}/DATETIME $1 $2 $3 $4 $5 $6 $7 $8 $9


### PR DESCRIPTION
File extensions have default file extension MLC for assember source and CBL for COBOL source. The bash scripts only allowed theses defaults. However, not-default file extensions are allowed for both. The bat files for assemblies and COBOL compiles have already been modified to suppurt this. The current pull request is doing the same for the bash scripts.