### PR TITLE
Publish Javadocs as part of z390 GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,10 @@ on:
       - main
       - doc/**
 
+env:
+  JAVA_DISTRIBUTION: temurin
+  JAVA_VERSION: 21
+
 jobs:
   deploy:
     name: Deploy docs
@@ -21,7 +25,12 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.11
+      - uses: actions/setup-java@v3
+        with:
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          java-version: ${{ env.JAVA_VERSION }}
       - run: pip install -r doc/requirements.txt
+      - run: bash/bldjavadoc doc/javadoc
       - run: mkdocs gh-deploy --force
         env:
           Z390_VERSION: ${{ steps.version.outputs.version }}

--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,0 +1,1 @@
+javadoc

--- a/doc/contributing/.pages
+++ b/doc/contributing/.pages
@@ -2,3 +2,4 @@ nav:
   - contribute_docs.md
   - contribute_code.md
   - contributing_zcobol.md
+  - z390 JavaDocs: /z390/javadoc/index.html

--- a/doc/contributing/contribute_code.md
+++ b/doc/contributing/contribute_code.md
@@ -74,6 +74,9 @@ the bldjar script.
         
     `bash> bash/bldjar`
 
+The published Java API documentation is available on GitHub Pages at
+[JavaDocs](../javadoc/index.html).
+
 ## Test the jar
 
 gradle info: https://docs.gradle.org/current/userguide/userguide.html

--- a/doc/contributing/contribute_code.md
+++ b/doc/contributing/contribute_code.md
@@ -61,6 +61,18 @@ This build procedure invokes the full regression testing script.
 Build and regression testing both can take quite some time.
 Luckily, you do not need to do this very often.
 
+### Update the code
+
+#### Code Style
+
+The project has not adopted any specific code style. The best guidance that can be 
+provided is to follow the existing style of code that already exists.
+
+#### Javadocs
+
+For Java code, ensure that any changes add or update the Javadocs comments
+so that the generated Javadocs are maintained.
+
 ### Rebuild the JAR
 
 You can just recompile the JAR without running the full build job by running
@@ -260,7 +272,7 @@ and create your own version under the GNU 2 license conditions.
 The following preamble should be applied to all programs
 
     z390 - Mainframe assembler emulator and run-time engine
-    Copyright (C) 2021 z390 Assembler LLC
+    Copyright (C) 20xx z390 Assembler LLC
 
     This file is part of z390.
     z390 is free software; you can redistribute it and/or modify
@@ -282,7 +294,7 @@ The following preamble should be applied to all programs
          MACRO
 .**********************************************************************
 .* z390 - Mainframe assembler emulator and run-time engine
-.* Copyright (C) 2021 z390 Assembler LLC
+.* Copyright (C) 20xx z390 Assembler LLC
 .*
 .* This file is part of z390.
 .*

--- a/doc/contributing/contribute_docs.md
+++ b/doc/contributing/contribute_docs.md
@@ -14,8 +14,6 @@ Markdown uses simple text files with specific syntax for formatting. See [the ma
 
 You can also use functions provided by the admonition extension in mkdocs. See the [doco for admonition](https://python-markdown.github.io/extensions/admonition/)
 
-**Note:** As part of the normal build process the documentation library for the Java code is generated from the java source code using the standard java tool javadoc.
-Generated documents can be found in z390 subdirectory build\javadoc or build/javadoc depending on your Operating System. These documents are *not* published to the web.
 
 ### Structure
 

--- a/doc/stylesheets/extra.css
+++ b/doc/stylesheets/extra.css
@@ -1,0 +1,16 @@
+/* Increase the size of Java icon in the footer */
+.md-social {
+  display: flex;
+  align-items: center;
+}
+
+.md-social__link {
+  font-size: 1.8rem;
+  height: 1.8rem;
+  display: inline-flex;
+  align-self: center;
+}
+
+.md-social__link svg {
+  max-height: 100%;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: z390
 site_author: z390 Development team
+site_url: https://z390development.github.io/z390/
 copyright: "&copy; 2026 z390 Assembler LLC. All rights reserved"
 repo_name: z390development/z390
 repo_url: https://github.com/z390development/z390
@@ -51,3 +52,9 @@ markdown_extensions:
 extra:
   version: !ENV [Z390_VERSION, 'Undefined']
   repo: !ENV [GITHUB_REPOSITORY, 'z390development/z390']
+  social:
+    - icon: fontawesome/brands/java
+      link: /z390/javadoc/index.html
+
+extra_css:
+  - stylesheets/extra.css


### PR DESCRIPTION
This PR will publish the generated JavaDocs to the docs site as part of the docs pipeline.
Javadocs are already generated as part of the build pipeline, and includes in the z390 distribution but were not available online. This change will publish the latest Javadocs at https://z390development.github.io/z390/javadocs.

To aide in finding the javadocs, 2 links have been added to the existing docs site:
* In the footer of the main documentation - clicking the Java icon will take you to the Java docs.
* In the Contributing Code page, it has a link referencing the Javadocs

You can preview the doc changes here: <https://adelosa.github.io/z390/>
Javadocs are available here: <https://adelosa.github.io/z390/javadoc>