### PR TITLE
Update GENCB ACB interface definition

### DIFF
--- a/doc/design/zVSAM/zVSAM_V2_Design_Interfaces.md
+++ b/doc/design/zVSAM/zVSAM_V2_Design_Interfaces.md
@@ -319,12 +319,16 @@ VSAM is the default and the only supported value.
 
 #### COPIES=
 
-Number of identical ACBs to generate. Defaults to 1.
+Number of identical ACBs to generate ranging from 1 to 65535. Defaults to 1.
 
 #### WAREA=
 
 The work area where the ACBs are to be constructed.
-If not specified, they will be created in storage that VSAM allocates on behalf of your program.
+
+- When WAREA is specified, LENGTH must be specified too.
+- When WAREA is not specified, the CBMR handler allocates an area of storage.
+- The address of this area whether via GETMAIN or WAREA is returned in R1.
+- The length of the generated ACB(s) is returned in R0.
 
 #### LENGTH=
 
@@ -336,6 +340,10 @@ If not specified, they will be created in storage that VSAM allocates on behalf 
 - If WAREA= is specified, this paramter is ignored.
 - If WAREA= is not specified, this parameter indicates where zVSAM is to allocate storage for the ACB or ACBs.
 
+Supported keywords:
+- BELOW = below 16M (addressable in Amode 24, 31, or 64)
+- ANY   = below 2G  (requires Amode 31 or 64 to address)
+
 #### Other keywords
 
 All parameters supported by the [ACB macro](#acb-macro) are supported here as well.
@@ -344,6 +352,15 @@ All parameters supported by the [ACB macro](#acb-macro) are supported here as we
 
 Indicates the Macro Format.
 If specified, the [label] subparameter is EQUated to the length of the CBMR.
+
+#### Return and Reason Codes
+
+| Return Code | Reason Code     | Meaning                                                                  |
+|-------------|-----------------|--------------------------------------------------------------------------|
+| R15=0       | Reason Code=n/a | Successful                                                               |
+| R15=4       | Reason Code=4   | Invalid control block                                                    |
+| R15=4       | Reason Code=9   | WAREA is too small                                                       |
+| R15=8       | Reason Code=n/a | An attempt was made to update a CBMR with a field not previously created |
 
 ### CBMR macro
 

--- a/doc/zVSAM/zVSAM_V2.4_Design_Interfaces.md
+++ b/doc/zVSAM/zVSAM_V2.4_Design_Interfaces.md
@@ -144,54 +144,6 @@ address means 'don't test the address'
 The lack of proper syntax checking in the IBM macro can cause access to low storage or
 environmental destruction, so the following syntaxes are not allowed: `(*,*)` and `(*,n)`.
 
-## GENCB BLK=ACB macro
-
-This GENCB macro will generate ACBs and initialize or change them according to the parameters specified
-on the macro invocation. It is for this reason that all supported parameters and keywords of the ACB macro
-(as described above) are supported on the GENCB macro.
-
-Direct access to subfields in the ACB is discouraged. Use SHOWCB ACB=, TESTCB ACB= and/or
-MODCB ACB= to inspect, test, and/or modify the ACB's content.
-
-Direct access to subfields in the CBMR is strongly discouraged.
-
-The GENCB ACB macro can be coded as follows:
-
-| Opcode        | Operand           | Remarks                                                                                                                         |
-|---------------|-------------------|---------------------------------------------------------------------------------------------------------------------------------|
-| [label] GENCB | BLK=ACB           | Instructs GENCB to generate 1 or more ACBs                                                                                      |
-|               | [AM=VSAM]         | Optional, no other values allowed                                                                                               |
-|               | [COPIES=1]        | The number of identical ACBs to generate. Specify a number between 1 and 65535                                                  |
-|               | [WAREA=address]   | The work area where the ACBs are to be constructed                                                                              |
-|               | [LENGTH=value]    | Length of the work area in bytes. If WAREA/LENGTH are omitted then storage is dynamically acquired and LOC=BELOW is the default |
-|               | [LOC=BELOW | ANY] | Where GENCB is to allocate dynamically acquired storage if needed                                                               |
-|               | **[other]**       | **Any parameter supported on the ACB macro**                                                                                    |
-|               | [MF=]             | See the [description of MF=](#MFdetails)                                                                                        |
-
-All supported parameters are implemented compatibly with IBM's VSAM implementation.
-For details, please refer to the relevant IBM manual.
-
-### WAREA=
-
-- When WAREA is specified, LENGTH must be specified too.
-- When WAREA is not specified, the CBMR handler allocates an area of storage
-- The address of this area whether via GETMAIN or WAREA is returned in R1
-- The length of the generated ACB(s) is returned in R0
-
-### LENGTH=
-
-Length in bytes of the area indicated by WAREA.
-When LENGTH is specified, WAREA must be specified as well.
-
-### Return (R15) and Reason (R0) Codes
-
-| Return Code | Reason Code     | Meaning                                                                  |
-|-------------|-----------------|--------------------------------------------------------------------------|
-| R15=0       | Reason Code=n/a | Successful                                                               |
-| R15=4       | Reason Code=4   | Invalid control block                                                    |
-| R15=4       | Reason Code=9   | WAREA is too small                                                       |
-| R15=8       | Reason Code=n/a | An attempt was made to update a CBMR with a field not previously created |
-
 ## GENCB BLK=EXLST macro
 
 The GENCB macro with BLK=EXLST will generate or manipulate Exit Lists for use with ACBs and


### PR DESCRIPTION
There is no issue describing this change.

What I did:
I discovered I'd missed the GENCB ACB description in Melvyn's V2.4 version of the design.
So I took that out and merged it into the new design document.