### PR TITLE
Check relver exit code in bash script bldjar

### DIFF
--- a/bash/bldjar
+++ b/bash/bldjar
@@ -35,6 +35,7 @@ if [ $ec -ne 0 ]; then echo "bldjar: Error compiling Java sources"; exit $ec; fi
 
 # create z390.properties file
 ../bash/relver $1
+ec=$?
 if [ $ec -ne 0 ]; then echo "bldjar: Error finding z390 version number"; exit $ec; fi
 
 # build z390.jar with the JDK jar utility


### PR DESCRIPTION
Fixes #931. The bldjar script does not capture the exit code from its invocation of relver. Add line to capture the exit code.