### PR TITLE
Issue 935   bras/jas instructions do not report the addr2 field correctly in the listing

### DIFF
--- a/src/az390.java
+++ b/src/az390.java
@@ -446,6 +446,7 @@ import javax.swing.JTextArea;
  * 2026-03-25 ZH  #704 Flag invalid register operands for KM, KMA, KMC
  * 2026-08-10 AFK #807 Fix issues flagged by linter
  * 2026-08-27 AFK #916 Missing break statements in case construct
+ * 2026-09-12 RJS #877 Do not display stale object code on error lines
  *****************************************************/
 
 
@@ -508,6 +509,7 @@ public  class  az390 implements Runnable {
     /** variable      */ boolean bal_label_ok = false; // RPI 451
     /** variable      */ String bal_parms = null;
     /** variable      */ boolean list_use = false;
+    /** variable      */ boolean list_line_in_error = false; // #877
     /** variable      */ int mac_inline_level = 0;      // rpi 581
     /** variable      */ int mac_inline_op_macro = 220; // rpi 581
     /** variable      */ int mac_inline_op_mend  = 221; // rpi 581
@@ -5947,50 +5949,7 @@ public  class  az390 implements Runnable {
         }
         loc_ctr = loc_ctr + loc_len;
     }
-   /**
-    * list bal line with first 8 bytes of
-    * object code if any 
-    * and turn off list_bal_line request
-    * <br />
-    * Note:
-    *    See comments processing case 0
-    *    for update of mac_call_gen,
-    *    call reformating, and delay flags
-    *    mac_call_first and mac_call_last.
-    * This routine is a clone of list_bal_line but
-    * excludes the PC and object code from the listing.   RPI 877
-    * If you change this routine, change list_bal_line() too.
-    */
-   private void list_bal_line_error(){
-       if (!check_list_bal_line()){ // RPI 484 RPI 891
-           update_list_bal_line();
-    	   return;
-       }
-       if (list_obj_code.length() < 16){
-          list_obj_code = list_obj_code.concat("                ").substring(0,16);
-       } 
-       list_obj_loc = loc_start;
-       if (gen_obj_code){ // RPI 581
-    	  cur_line_type     = xref_file_type[bal_line_xref_file_num[bal_line_index]];
-    	  cur_line_file_num = bal_line_xref_file_num[bal_line_index];
-    	  put_prn_line("      "       // Do not diplay the PC on error lines  RPI 877
-		    + " " + list_obj_code.substring(0,16) 
-		    + " " + hex_bddd1_loc 
-		    + " " + hex_bddd2_loc 
-		    + " " + tz390.get_cur_bal_line_id(cur_line_file_num,
-                  bal_line_xref_file_line[bal_line_index],
-                  bal_line_num[bal_line_index],
-                  mac_call_gen, // RPI 891 
-                  cur_line_type) 
-		    + bal_line);
-       }
-       force_list_bal = false;   // RPI 285
-       update_list_bal_line();
-       if (list_use){
-    	  list_use();
-    	  list_use = false;
-       }
-    }
+
 
 
     /**
@@ -6003,7 +5962,6 @@ public  class  az390 implements Runnable {
      *    for update of mac_call_gen,
      *    call reformating, and delay flags
      *    mac_call_first and mac_call_last.
-     * If you change this routine, change list_bal_line_error() too.
      */
     private void list_bal_line() {
         if (!check_list_bal_line()) { // RPI 484 RPI 891
@@ -6017,16 +5975,16 @@ public  class  az390 implements Runnable {
         if (gen_obj_code) { // RPI 581
             cur_line_type     = xref_file_type[bal_line_xref_file_num[bal_line_index]];
             cur_line_file_num = bal_line_xref_file_num[bal_line_index];
-            put_prn_line(tz390.get_hex(list_obj_loc,6)
-                    + " " + list_obj_code.substring(0,16)
-                    + " " + hex_bddd1_loc
-                    + " " + hex_bddd2_loc
-                    + " " + tz390.get_cur_bal_line_id(cur_line_file_num,
-                            bal_line_xref_file_line[bal_line_index],
-                            bal_line_num[bal_line_index],
-                            mac_call_gen, // RPI 891
-                            cur_line_type)
-                    + bal_line);
+            put_prn_line((list_line_in_error ? "      " : tz390.get_hex(list_obj_loc,6)) // Conditional PC #877
+		        + " " + list_obj_code.substring(0,16) 
+		        + " " + hex_bddd1_loc 
+		        + " " + hex_bddd2_loc 
+		        + " " + tz390.get_cur_bal_line_id(cur_line_file_num,
+                    bal_line_xref_file_line[bal_line_index],
+                    bal_line_num[bal_line_index],
+                    mac_call_gen, // RPI 891 
+                    cur_line_type) 
+		        + bal_line);
         }
         force_list_bal = false;   // RPI 285
         update_list_bal_line();
@@ -8358,10 +8316,12 @@ public  class  az390 implements Runnable {
         if (gen_obj_code) { // RPI 484
             if (!mz390_abort) { // RPI 433 don't duplicate mz error line
                 force_list_bal = true;  // RPI 285
-                list_obj_code = "";             // RPI 877
-                hex_bddd1_loc = "      ";       // RPI 877
-                hex_bddd2_loc = "      ";       // RPI 877
-			    list_bal_line_error();          // RPI 877
+                list_obj_code = "";             // #877
+                hex_bddd1_loc = "      ";       // #877
+                hex_bddd2_loc = "      ";       // #877
+                list_line_in_error = true;      // Take the error path in list_bal_line() #877
+			    list_bal_line();                // #877
+                list_line_in_error = false;     // Reset the flag #877
             }
             force_list_bal = true;  // RPI 285
             set_file_line_xref();

--- a/src/az390.java
+++ b/src/az390.java
@@ -5947,7 +5947,50 @@ public  class  az390 implements Runnable {
         }
         loc_ctr = loc_ctr + loc_len;
     }
-
+   /**
+    * list bal line with first 8 bytes of
+    * object code if any 
+    * and turn off list_bal_line request
+    * <br />
+    * Note:
+    *    See comments processing case 0
+    *    for update of mac_call_gen,
+    *    call reformating, and delay flags
+    *    mac_call_first and mac_call_last.
+    * This routine is a clone of list_bal_line but
+    * excludes the PC and object code from the listing.   RPI 877
+    * If you change this routine, change list_bal_line() too.
+    */
+   private void list_bal_line_error(){
+       if (!check_list_bal_line()){ // RPI 484 RPI 891
+           update_list_bal_line();
+    	   return;
+       }
+       if (list_obj_code.length() < 16){
+          list_obj_code = list_obj_code.concat("                ").substring(0,16);
+       } 
+       list_obj_loc = loc_start;
+       if (gen_obj_code){ // RPI 581
+    	  cur_line_type     = xref_file_type[bal_line_xref_file_num[bal_line_index]];
+    	  cur_line_file_num = bal_line_xref_file_num[bal_line_index];
+    	  put_prn_line("      "       // Do not diplay the PC on error lines  RPI 877
+		    + " " + list_obj_code.substring(0,16) 
+		    + " " + hex_bddd1_loc 
+		    + " " + hex_bddd2_loc 
+		    + " " + tz390.get_cur_bal_line_id(cur_line_file_num,
+                  bal_line_xref_file_line[bal_line_index],
+                  bal_line_num[bal_line_index],
+                  mac_call_gen, // RPI 891 
+                  cur_line_type) 
+		    + bal_line);
+       }
+       force_list_bal = false;   // RPI 285
+       update_list_bal_line();
+       if (list_use){
+    	  list_use();
+    	  list_use = false;
+       }
+    }
 
 
     /**
@@ -5960,6 +6003,7 @@ public  class  az390 implements Runnable {
      *    for update of mac_call_gen,
      *    call reformating, and delay flags
      *    mac_call_first and mac_call_last.
+     * If you change this routine, change list_bal_line_error() too.
      */
     private void list_bal_line() {
         if (!check_list_bal_line()) { // RPI 484 RPI 891
@@ -8314,7 +8358,10 @@ public  class  az390 implements Runnable {
         if (gen_obj_code) { // RPI 484
             if (!mz390_abort) { // RPI 433 don't duplicate mz error line
                 force_list_bal = true;  // RPI 285
-                list_bal_line();
+                list_obj_code = "";             // RPI 877
+                hex_bddd1_loc = "      ";       // RPI 877
+                hex_bddd2_loc = "      ";       // RPI 877
+			    list_bal_line_error();          // RPI 877
             }
             force_list_bal = true;  // RPI 285
             set_file_line_xref();


### PR DESCRIPTION
The fix involved settinng the ADDR2 internal variable under the context of certain relative addressing mode instructions.  With the fix in place, the following output is produced:
```

000074 4120D06C                000074       (1/9)108          LA    R2,*
000078 E330D0700071            000078      (1/10)109          LAY   R3,*
00007E C04000000000            00007E      (1/11)110          LARL  R4,*
000084 4D50D080                000088      (1/12)111          BAS   R5,*+4
000088 A7650002                00008C      (1/13)112          BRAS  R6,*+4
00008C C07500000003            000092      (1/14)113          BRASL R7,*+6
000092 A7850002                000096      (1/15)114          JAS   R8,*+4
000096 C09500000003            00009C      (1/16)115          JASL  R9,*+6
00009C A7840002                0000A0      (1/17)116          JC    B'1000',*+4
0000A0 A7740002                0000A4      (1/18)117          JNE   *+4
0000A4                                     (1/20)118 RETURN   SUBEXIT RC=(R15)
```